### PR TITLE
Added run options for WSL

### DIFF
--- a/conf/test.config
+++ b/conf/test.config
@@ -22,3 +22,11 @@ params {
     // Input data
     input  = 'https://raw.githubusercontent.com/phac-nml/gasclustering/dev/assets/samplesheet.csv'
 }
+
+
+/* This is required to run in WSL/Ubuntu using singularity
+Without this, profile_dists was not successfully completing
+due to issues with multiprocessing in the container. A similar
+error is found at https://github.com/marcelm/cutadapt/issues/583
+*/
+singularity.runOptions = "--contain"

--- a/tests/nextflow.config
+++ b/tests/nextflow.config
@@ -8,5 +8,12 @@ params.max_memory = "2.GB"
 params.max_cpus = 1
 params.av_html = "$baseDir/assets/ArborView.html"
 
+/* This is required to run in WSL/Ubuntu using singularity
+Without this, profile_dists was not successfully completing
+due to issues with multiprocessing in the container. A similar
+error is found at https://github.com/marcelm/cutadapt/issues/583
+*/
+singularity.runOptions = "--contain"
+
 /* Remove gzipping on JSON output for testing/asserts on file contents */
 iridanext.output.path = "${params.outdir}/iridanext.output.json"


### PR DESCRIPTION
<!--
# phac-nml/iridanextexample pull request

Many thanks for contributing to phac-nml/iridanextexample!

Please fill in the appropriate checklist below (delete whatever is not relevant).
These are the most common things requested on pull requests (PRs).

Remember that PRs should be made against the dev branch, unless you're preparing a pipeline release.

Learn more about contributing: [CONTRIBUTING.md](https://github.com/phac-nml/iridanextexample/tree/main/.github/CONTRIBUTING.md)
-->

This fixes an issue with running the pipeline in WSL with singularity with Python multiprocessing. The exception I was getting is:

```
    File "/usr/local/lib/python3.11/multiprocessing/synchronize.py", line 169, in __init__
      SemLock.__init__(self, SEMAPHORE, 1, 1, ctx=ctx)
    File "/usr/local/lib/python3.11/multiprocessing/synchronize.py", line 57, in __init__
      sl = self._semlock = _multiprocessing.SemLock(
                           ^^^^^^^^^^^^^^^^^^^^^^^^^
  FileNotFoundError: [Errno 2] No such file or directory
```

Setting `singularity.runOptions = "--contain"` fixes this. I only set this for tests right now since I'm not sure if this has any consequence in running outside of WSL or in Azure.

## PR checklist

- [x] This comment contains a description of changes (with reason).
- [x] If you've fixed a bug or added code that should be tested, add tests!
- [x] Make sure your code lints (`nf-core lint`).
- [x] Ensure the test suite passes (`nextflow run . -profile test,docker --outdir <OUTDIR>`).
