### PR TITLE
Adding Support for Metadata

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -24,6 +24,8 @@ indent_size = unset
 indent_size = unset
 
 [/assets/ArborView.html]
+[tests/data/append/expected_clusters_and_metadata_little_metadata.tsv]
+[tests/data/append/expected_clusters_and_metadata_no_metadata.tsv]
 trim_trailing_whitespace = unset
 
 # ignore Readme

--- a/.editorconfig
+++ b/.editorconfig
@@ -24,7 +24,11 @@ indent_size = unset
 indent_size = unset
 
 [/assets/ArborView.html]
+trim_trailing_whitespace = unset
+
 [tests/data/append/expected_clusters_and_metadata_little_metadata.tsv]
+trim_trailing_whitespace = unset
+
 [tests/data/append/expected_clusters_and_metadata_no_metadata.tsv]
 trim_trailing_whitespace = unset
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,26 +5,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## In-development
 
-- Fixed nf-core tools linting failures introduced in version 2.12.1.
-- Added phac-nml prefix to nf-core config
+- Initial release of phac-nml/gasclustering.
 - Added support for metadata.
-
-## 1.0.3 - 2024/02/23
-
-- Pinned nf-validation@1.1.3 plugin
-
-## 1.0.2 - 2023/12/18
-
-- Removed GitHub workflows that weren't needed.
-- Adding additional parameters for testing purposes.
-
-## 1.0.1 - 2023/12/06
-
-Allowing non-gzipped FASTQ files as input. Default branch is now main.
-
-## 1.0.0 - 2023/11/30
-
-Initial release of phac-nml/gasclustering, created with the [nf-core](https://nf-co.re/) template.
 
 ### `Added`
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Fixed nf-core tools linting failures introduced in version 2.12.1.
 - Added phac-nml prefix to nf-core config
+- Added support for metadata.
 
 ## 1.0.3 - 2024/02/23
 

--- a/README.md
+++ b/README.md
@@ -8,9 +8,9 @@ This workflow takes provided JSON-formatted MLST profiles and converts them into
 
 The input to the pipeline is a standard sample sheet (passed as `--input samplesheet.csv`) that looks like:
 
-| sample  | mlst_alleles       | metadata_1 | metadata_2 | metadata_3 | metadata_4 | metadata_5 | metadata_6 | metadata_7 | metadata_8 |
-| ------- | ------------------ | ---------- | ---------- | ---------- | ---------- | ---------- | ---------- |----------- | ---------- |
-| SampleA | sampleA.mlst.json  | meta1      | meta2      | meta3      | meta4      | meta5      | meta6      | meta7      | meta8      |
+| sample  | mlst_alleles      | metadata_1 | metadata_2 | metadata_3 | metadata_4 | metadata_5 | metadata_6 | metadata_7 | metadata_8 |
+| ------- | ----------------- | ---------- | ---------- | ---------- | ---------- | ---------- | ---------- | ---------- | ---------- |
+| SampleA | sampleA.mlst.json | meta1      | meta2      | meta3      | meta4      | meta5      | meta6      | meta7      | meta8      |
 
 The structure of this file is defined in [assets/schema_input.json](assets/schema_input.json). Validation of the sample sheet is performed by [nf-validation](https://nextflow-io.github.io/nf-validation/).
 
@@ -81,12 +81,12 @@ An example of the what the contents of the IRIDA Next JSON file looks like for t
             }
         ],
         "samples": {
-            
+
         }
     },
     "metadata": {
         "samples": {
-            
+
         }
     }
 }

--- a/README.md
+++ b/README.md
@@ -1,16 +1,16 @@
 [![Nextflow](https://img.shields.io/badge/nextflow-%E2%89%A523.04.3-brightgreen.svg)](https://www.nextflow.io/)
 
-# Example Pipeline for IRIDA Next
+# Genomic Address Service Clustering Workflow
 
-This is an example pipeline to be used for integration with IRIDA Next.
+This workflow takes provided JSON-formatted MLST profiles and converts them into a phylogenetic tree with associated flat cluster codes for use in [Irida Next](https://github.com/phac-nml/irida-next). The workflow also generates a interactive tree for visualization.
 
 # Input
 
 The input to the pipeline is a standard sample sheet (passed as `--input samplesheet.csv`) that looks like:
 
-| sample  | fastq_1         | fastq_2         |
-| ------- | --------------- | --------------- |
-| SampleA | file_1.fastq.gz | file_2.fastq.gz |
+| sample  | mlst_alleles       | metadata_1 | metadata_2 | metadata_3 | metadata_4 | metadata_5 | metadata_6 | metadata_7 | metadata_8 |
+| ------- | ------------------ | ---------- | ---------- | ---------- | ---------- | ---------- | ---------- |----------- | ---------- |
+| SampleA | sampleA.mlst.json  | meta1      | meta2      | meta3      | meta4      | meta5      | meta6      | meta7      | meta8      |
 
 The structure of this file is defined in [assets/schema_input.json](assets/schema_input.json). Validation of the sample sheet is performed by [nf-validation](https://nextflow-io.github.io/nf-validation/).
 
@@ -47,41 +47,46 @@ An example of the what the contents of the IRIDA Next JSON file looks like for t
     "files": {
         "global": [
             {
-                "path": "summary/summary.txt.gz"
+                "path": "ArborView/clustered_data_arborview.html"
+            },
+            {
+                "path": "clusters/run.json"
+            },
+            {
+                "path": "clusters/tree.nwk"
+            },
+            {
+                "path": "clusters/clusters.text"
+            },
+            {
+                "path": "clusters/thresholds.json"
+            },
+            {
+                "path": "distances/run.json"
+            },
+            {
+                "path": "distances/results.text"
+            },
+            {
+                "path": "distances/ref_profile.text"
+            },
+            {
+                "path": "distances/query_profile.text"
+            },
+            {
+                "path": "distances/allele_map.json"
+            },
+            {
+                "path": "merged/profile.tsv"
             }
         ],
         "samples": {
-            "SAMPLE1": [
-                {
-                    "path": "assembly/SAMPLE1.assembly.fa.gz"
-                }
-            ],
-            "SAMPLE2": [
-                {
-                    "path": "assembly/SAMPLE2.assembly.fa.gz"
-                }
-            ],
-            "SAMPLE3": [
-                {
-                    "path": "assembly/SAMPLE3.assembly.fa.gz"
-                }
-            ]
+            
         }
     },
     "metadata": {
         "samples": {
-            "SAMPLE1": {
-                "reads.1": "sample1_R1.fastq.gz",
-                "reads.2": "sample1_R2.fastq.gz"
-            },
-            "SAMPLE2": {
-                "reads.1": "sample2_R1.fastq.gz",
-                "reads.2": "sample2_R2.fastq.gz"
-            },
-            "SAMPLE3": {
-                "reads.1": "sample1_R1.fastq.gz",
-                "reads.2": "null"
-            }
+            
         }
     }
 }
@@ -101,7 +106,7 @@ nextflow run phac-nml/gasclustering -profile docker,test -r main -latest --outdi
 
 # Legal
 
-Copyright 2023 Government of Canada
+Copyright 2024 Government of Canada
 
 Licensed under the MIT License (the "License"); you may not use
 this work except in compliance with the License. You may obtain a copy of the

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 # Genomic Address Service Clustering Workflow
 
-This workflow takes provided JSON-formatted MLST profiles and converts them into a phylogenetic tree with associated flat cluster codes for use in [Irida Next](https://github.com/phac-nml/irida-next). The workflow also generates a interactive tree for visualization.
+This workflow takes provided JSON-formatted MLST profiles and converts them into a phylogenetic tree with associated flat cluster codes for use in [Irida Next](https://github.com/phac-nml/irida-next). The workflow also generates an interactive tree for visualization.
 
 # Input
 

--- a/README.md
+++ b/README.md
@@ -18,6 +18,12 @@ The structure of this file is defined in [assets/schema_input.json](assets/schem
 
 The main parameters are `--input` as defined above and `--output` for specifying the output results directory. You may wish to provide `-profile singularity` to specify the use of singularity containers and `-r [branch]` to specify which GitHub branch you would like to run.
 
+## Metadata
+
+In order to customize metadata headers, the parameters `--metadata_1_header` through `--metadata_8_header` may be specified.
+
+## Other
+
 Other parameters (defaults from nf-core) are defined in [nextflow_schema.json](nextflow_schmea.json).
 
 # Running

--- a/assets/schema_input.json
+++ b/assets/schema_input.json
@@ -20,6 +20,47 @@
                 "pattern": "^\\S+\\.mlst\\.json(\\.gz)?$",
                 "errorMessage": "MLST JSON file from locidex report, cannot contain spaces and must have the extension: '.mlst.json' or '.mlst.json.gz'"
             }
+            ,
+            "metadata_1": {
+                "type": "string",
+                "errorMessage": "Metadata associated with the sample (metadata_1).",
+                "default": ""
+            },
+            "metadata_2": {
+                "type": "string",
+                "errorMessage": "Metadata associated with the sample (metadata_2).",
+                "default": ""
+            },
+            "metadata_3": {
+                "type": "string",
+                "errorMessage": "Metadata associated with the sample (metadata_3).",
+                "default": ""
+            },
+            "metadata_4": {
+                "type": "string",
+                "errorMessage": "Metadata associated with the sample (metadata_4).",
+                "default": ""
+            },
+            "metadata_5": {
+                "type": "string",
+                "errorMessage": "Metadata associated with the sample (metadata_5).",
+                "default": ""
+            },
+            "metadata_6": {
+                "type": "string",
+                "errorMessage": "Metadata associated with the sample (metadata_6).",
+                "default": ""
+            },
+            "metadata_7": {
+                "type": "string",
+                "errorMessage": "Metadata associated with the sample (metadata_7).",
+                "default": ""
+            },
+            "metadata_8": {
+                "type": "string",
+                "errorMessage": "Metadata associated with the sample (metadata_8).",
+                "default": ""
+            }
         },
         "required": ["sample", "mlst_alleles"]
     }

--- a/assets/schema_input.json
+++ b/assets/schema_input.json
@@ -24,49 +24,57 @@
                 "type": "string",
                 "meta": ["metadata_1"],
                 "errorMessage": "Metadata associated with the sample (metadata_1).",
-                "default": ""
+                "default": "",
+                "pattern": "^[^\\n\\t\"]+$"
             },
             "metadata_2": {
                 "type": "string",
                 "meta": ["metadata_2"],
                 "errorMessage": "Metadata associated with the sample (metadata_2).",
-                "default": ""
+                "default": "",
+                "pattern": "^[^\\n\\t\"]+$"
             },
             "metadata_3": {
                 "type": "string",
                 "meta": ["metadata_3"],
                 "errorMessage": "Metadata associated with the sample (metadata_3).",
-                "default": ""
+                "default": "",
+                "pattern": "^[^\\n\\t\"]+$"
             },
             "metadata_4": {
                 "type": "string",
                 "meta": ["metadata_4"],
                 "errorMessage": "Metadata associated with the sample (metadata_4).",
-                "default": ""
+                "default": "",
+                "pattern": "^[^\\n\\t\"]+$"
             },
             "metadata_5": {
                 "type": "string",
                 "meta": ["metadata_5"],
                 "errorMessage": "Metadata associated with the sample (metadata_5).",
-                "default": ""
+                "default": "",
+                "pattern": "^[^\\n\\t\"]+$"
             },
             "metadata_6": {
                 "type": "string",
                 "meta": ["metadata_6"],
                 "errorMessage": "Metadata associated with the sample (metadata_6).",
-                "default": ""
+                "default": "",
+                "pattern": "^[^\\n\\t\"]+$"
             },
             "metadata_7": {
                 "type": "string",
                 "meta": ["metadata_7"],
                 "errorMessage": "Metadata associated with the sample (metadata_7).",
-                "default": ""
+                "default": "",
+                "pattern": "^[^\\n\\t\"]+$"
             },
             "metadata_8": {
                 "type": "string",
                 "meta": ["metadata_8"],
                 "errorMessage": "Metadata associated with the sample (metadata_8).",
-                "default": ""
+                "default": "",
+                "pattern": "^[^\\n\\t\"]+$"
             }
         },
         "required": ["sample", "mlst_alleles"]

--- a/assets/schema_input.json
+++ b/assets/schema_input.json
@@ -22,41 +22,49 @@
             },
             "metadata_1": {
                 "type": "string",
+                "meta": ["metadata_1"],
                 "errorMessage": "Metadata associated with the sample (metadata_1).",
                 "default": ""
             },
             "metadata_2": {
                 "type": "string",
+                "meta": ["metadata_2"],
                 "errorMessage": "Metadata associated with the sample (metadata_2).",
                 "default": ""
             },
             "metadata_3": {
                 "type": "string",
+                "meta": ["metadata_3"],
                 "errorMessage": "Metadata associated with the sample (metadata_3).",
                 "default": ""
             },
             "metadata_4": {
                 "type": "string",
+                "meta": ["metadata_4"],
                 "errorMessage": "Metadata associated with the sample (metadata_4).",
                 "default": ""
             },
             "metadata_5": {
                 "type": "string",
+                "meta": ["metadata_5"],
                 "errorMessage": "Metadata associated with the sample (metadata_5).",
                 "default": ""
             },
             "metadata_6": {
                 "type": "string",
+                "meta": ["metadata_6"],
                 "errorMessage": "Metadata associated with the sample (metadata_6).",
                 "default": ""
             },
             "metadata_7": {
                 "type": "string",
+                "meta": ["metadata_7"],
                 "errorMessage": "Metadata associated with the sample (metadata_7).",
                 "default": ""
             },
             "metadata_8": {
                 "type": "string",
+                "meta": ["metadata_8"],
                 "errorMessage": "Metadata associated with the sample (metadata_8).",
                 "default": ""
             }

--- a/assets/schema_input.json
+++ b/assets/schema_input.json
@@ -19,8 +19,7 @@
                 "format": "file-path",
                 "pattern": "^\\S+\\.mlst\\.json(\\.gz)?$",
                 "errorMessage": "MLST JSON file from locidex report, cannot contain spaces and must have the extension: '.mlst.json' or '.mlst.json.gz'"
-            }
-            ,
+            },
             "metadata_1": {
                 "type": "string",
                 "errorMessage": "Metadata associated with the sample (metadata_1).",

--- a/modules/local/appendmetadata/main.nf
+++ b/modules/local/appendmetadata/main.nf
@@ -6,22 +6,47 @@ process APPEND_METADATA {
     val clusters_path  // cluster data as a TSV path
                         // this needs to be "val", because "path"
                         // won't stage the file correctly for exec
-    val metadata  // metadata to be appended, list of lists
+    val metadata_rows  // metadata rows (no headers) to be appened, list of lists
+    val metadata_headers  // headers to name the metadata columns
 
     output:
     path("clusters_and_metadata.tsv"), emit: clusters
 
     exec:
+    def clusters_rows  // has a header row
+    def clusters_rows_map = [:]
+    def metadata_rows_map = [:]
     def merged = []
-    def rows
 
     clusters_path.withReader { reader ->
-        rows = reader.readLines()*.split('\t')
+        clusters_rows = reader.readLines()*.split('\t')
     }
 
-    for(int i = 0; i < rows.size(); i++)
+    // Create a map of the cluster rows:
+    // Start on i = 1 because we don't want the headers.
+    for(int i = 1; i < clusters_rows.size(); i++)
     {
-        merged.add(rows[i] + metadata[i])
+        // "sample" -> ["sample", 1, 2, 3, ...]
+        clusters_rows_map[clusters_rows[i][0]] = clusters_rows[i]
+    }
+
+    // Create a map of the metadata rows:
+    // Start on i = 0 because there are no headers included.
+    for(int i = 0; i < metadata_rows.size(); i++)
+    {
+        // "sample" -> ["sample", meta1, meta2, meta3, ...]
+        metadata_rows_map[metadata_rows[i][0]] = metadata_rows[i]
+    }
+
+    // Merge the headers
+    merged.add(clusters_rows[0] + metadata_headers)
+
+    // Merge the remain rows in original order:
+    // Start on i = 1 because we don't want the headers.
+    for(int i = 1; i < clusters_rows.size(); i++)
+    {
+        def sample_key = clusters_rows[i][0]
+        merged.add(clusters_rows_map[sample_key] + metadata_rows_map[sample_key][1..-1])
     }
 
     task.workDir.resolve("clusters_and_metadata.tsv").withWriter { writer ->

--- a/modules/local/appendmetadata/main.nf
+++ b/modules/local/appendmetadata/main.nf
@@ -1,6 +1,6 @@
 process APPEND_METADATA {
     tag "append_metadata"
-    label 'process_low'
+    label 'process_single'
 
     input:
     val clusters_path  // cluster data as a TSV path

--- a/modules/local/appendmetadata/main.nf
+++ b/modules/local/appendmetadata/main.nf
@@ -4,8 +4,8 @@ process APPEND_METADATA {
 
     input:
     val clusters_path  // cluster data as a TSV path
-                       // this needs to be "val", because "path"
-                       // won't stage the file correctly for exec
+                        // this needs to be "val", because "path"
+                        // won't stage the file correctly for exec
     val metadata  // metadata to be appended, list of lists
 
     output:
@@ -14,7 +14,7 @@ process APPEND_METADATA {
     exec:
     def merged = []
     def rows
-    
+
     clusters_path.withReader { reader ->
         rows = reader.readLines()*.split('\t')
     }

--- a/modules/local/appendmetadata/main.nf
+++ b/modules/local/appendmetadata/main.nf
@@ -1,0 +1,31 @@
+process APPEND_METADATA {
+    tag "append_metadata"
+    label 'process_low'
+
+    input:
+    val clusters_path  // cluster data as a TSV path
+                       // this needs to be "val", because "path"
+                       // won't stage the file correctly for exec
+    val metadata  // metadata to be appended, list of lists
+
+    output:
+    path("clusters_and_metadata.tsv"), emit: clusters
+
+    exec:
+    def merged = []
+    def rows
+    
+    clusters_path.withReader { reader ->
+        rows = reader.readLines()*.split('\t')
+    }
+
+    for(int i = 0; i < rows.size(); i++)
+    {
+        merged.add(rows[i] + metadata[i])
+    }
+
+    task.workDir.resolve("clusters_and_metadata.tsv").withWriter { writer ->
+        merged.each { writer.writeLine it.join("\t") }
+    }
+
+}

--- a/nextflow.config
+++ b/nextflow.config
@@ -63,6 +63,16 @@ params {
     // Arborview specific data
     // TODO check this works in azure
     av_html = "./assets/ArborView.html"
+
+    // Metadata
+    metadata_1_header = "metadata_1"
+    metadata_2_header = "metadata_2"
+    metadata_3_header = "metadata_3"
+    metadata_4_header = "metadata_4"
+    metadata_5_header = "metadata_5"
+    metadata_6_header = "metadata_6"
+    metadata_7_header = "metadata_7"
+    metadata_8_header = "metadata_8"
 }
 
 // Load base.config by default for all pipelines

--- a/nextflow_schema.json
+++ b/nextflow_schema.json
@@ -39,10 +39,10 @@
                 }
             }
         },
-        "new_group_1": {
-            "title": "New Group 1",
+        "metadata": {
+            "title": "Metadata",
             "type": "object",
-            "description": "",
+            "description": "The column header names of the metadata columns.",
             "default": "",
             "properties": {
                 "metadata_1_header": {
@@ -338,7 +338,7 @@
             "$ref": "#/definitions/input_output_options"
         },
         {
-            "$ref": "#/definitions/new_group_1"
+            "$ref": "#/definitions/metadata"
         },
         {
             "$ref": "#/definitions/profile_dists"

--- a/nextflow_schema.json
+++ b/nextflow_schema.json
@@ -39,6 +39,63 @@
                 }
             }
         },
+        "new_group_1": {
+            "title": "New Group 1",
+            "type": "object",
+            "description": "",
+            "default": "",
+            "properties": {
+                "metadata_1_header": {
+                    "type": "string",
+                    "default": "metadata_1",
+                    "description": "The header name of metadata column 1.",
+                    "fa_icon": "far fa-sticky-note"
+                },
+                "metadata_2_header": {
+                    "type": "string",
+                    "default": "metadata_2",
+                    "description": "The header name of metadata column 2.",
+                    "fa_icon": "far fa-sticky-note"
+                },
+                "metadata_3_header": {
+                    "type": "string",
+                    "default": "metadata_3",
+                    "description": "The header name of metadata column 3.",
+                    "fa_icon": "far fa-sticky-note"
+                },
+                "metadata_4_header": {
+                    "type": "string",
+                    "default": "metadata_4",
+                    "description": "The header name of metadata column 4.",
+                    "fa_icon": "far fa-sticky-note"
+                },
+                "metadata_5_header": {
+                    "type": "string",
+                    "default": "metadata_5",
+                    "description": "The header name of metadata column 5.",
+                    "fa_icon": "far fa-sticky-note"
+                },
+                "metadata_6_header": {
+                    "type": "string",
+                    "default": "metadata_6",
+                    "description": "The header name of metadata column 6.",
+                    "fa_icon": "far fa-sticky-note"
+                },
+                "metadata_7_header": {
+                    "type": "string",
+                    "default": "metadata_7",
+                    "description": "The header name of metadata column 7.",
+                    "fa_icon": "far fa-sticky-note"
+                },
+                "metadata_8_header": {
+                    "type": "string",
+                    "default": "metadata_8",
+                    "description": "The header name of metadata column 8.",
+                    "fa_icon": "far fa-sticky-note"
+                }
+            },
+            "fa_icon": "far fa-clipboard"
+        },
         "profile_dists": {
             "title": "Profile Dists",
             "type": "object",
@@ -55,15 +112,15 @@
                 },
                 "pd_missing_threshold": {
                     "type": "number",
-                    "default": 1.0
+                    "default": 1
                 },
                 "pd_sample_quality_threshold": {
                     "type": "number",
-                    "default": 1.0
+                    "default": 1
                 },
                 "pd_match_threshold": {
                     "type": "number",
-                    "default": -1.0
+                    "default": -1
                 },
                 "pd_file_type": {
                     "type": "string",
@@ -281,6 +338,9 @@
             "$ref": "#/definitions/input_output_options"
         },
         {
+            "$ref": "#/definitions/new_group_1"
+        },
+        {
             "$ref": "#/definitions/profile_dists"
         },
         {
@@ -298,39 +358,5 @@
         {
             "$ref": "#/definitions/generic_options"
         }
-    ],
-    "properties": {
-        "metadata_1_header": {
-            "type": "string",
-            "default": "metadata_1"
-        },
-        "metadata_2_header": {
-            "type": "string",
-            "default": "metadata_2"
-        },
-        "metadata_3_header": {
-            "type": "string",
-            "default": "metadata_3"
-        },
-        "metadata_4_header": {
-            "type": "string",
-            "default": "metadata_4"
-        },
-        "metadata_5_header": {
-            "type": "string",
-            "default": "metadata_5"
-        },
-        "metadata_6_header": {
-            "type": "string",
-            "default": "metadata_6"
-        },
-        "metadata_7_header": {
-            "type": "string",
-            "default": "metadata_7"
-        },
-        "metadata_8_header": {
-            "type": "string",
-            "default": "metadata_8"
-        }
-    }
+    ]
 }

--- a/nextflow_schema.json
+++ b/nextflow_schema.json
@@ -10,10 +10,7 @@
             "type": "object",
             "fa_icon": "fas fa-terminal",
             "description": "Define where the pipeline should find input data and save output data.",
-            "required": [
-                "input",
-                "outdir"
-            ],
+            "required": ["input", "outdir"],
             "properties": {
                 "input": {
                     "type": "string",
@@ -283,14 +280,7 @@
                     "description": "Method used to save pipeline results to output directory.",
                     "help_text": "The Nextflow `publishDir` option specifies which intermediate files should be saved to the output directory. This option tells the pipeline what method should be used to move these files. See [Nextflow docs](https://www.nextflow.io/docs/latest/process.html#publishdir) for details.",
                     "fa_icon": "fas fa-copy",
-                    "enum": [
-                        "symlink",
-                        "rellink",
-                        "link",
-                        "copy",
-                        "copyNoFollow",
-                        "move"
-                    ],
+                    "enum": ["symlink", "rellink", "link", "copy", "copyNoFollow", "move"],
                     "hidden": true
                 },
                 "email_on_fail": {

--- a/nextflow_schema.json
+++ b/nextflow_schema.json
@@ -10,7 +10,10 @@
             "type": "object",
             "fa_icon": "fas fa-terminal",
             "description": "Define where the pipeline should find input data and save output data.",
-            "required": ["input", "outdir"],
+            "required": [
+                "input",
+                "outdir"
+            ],
             "properties": {
                 "input": {
                     "type": "string",
@@ -49,49 +52,57 @@
                     "type": "string",
                     "default": "metadata_1",
                     "description": "The header name of metadata column 1.",
-                    "fa_icon": "far fa-sticky-note"
+                    "fa_icon": "far fa-sticky-note",
+                    "pattern": "^[^\\n\\t\"]+$"
                 },
                 "metadata_2_header": {
                     "type": "string",
                     "default": "metadata_2",
                     "description": "The header name of metadata column 2.",
-                    "fa_icon": "far fa-sticky-note"
+                    "fa_icon": "far fa-sticky-note",
+                    "pattern": "^[^\\n\\t\"]+$"
                 },
                 "metadata_3_header": {
                     "type": "string",
                     "default": "metadata_3",
                     "description": "The header name of metadata column 3.",
-                    "fa_icon": "far fa-sticky-note"
+                    "fa_icon": "far fa-sticky-note",
+                    "pattern": "^[^\\n\\t\"]+$"
                 },
                 "metadata_4_header": {
                     "type": "string",
                     "default": "metadata_4",
                     "description": "The header name of metadata column 4.",
-                    "fa_icon": "far fa-sticky-note"
+                    "fa_icon": "far fa-sticky-note",
+                    "pattern": "^[^\\n\\t\"]+$"
                 },
                 "metadata_5_header": {
                     "type": "string",
                     "default": "metadata_5",
                     "description": "The header name of metadata column 5.",
-                    "fa_icon": "far fa-sticky-note"
+                    "fa_icon": "far fa-sticky-note",
+                    "pattern": "^[^\\n\\t\"]+$"
                 },
                 "metadata_6_header": {
                     "type": "string",
                     "default": "metadata_6",
                     "description": "The header name of metadata column 6.",
-                    "fa_icon": "far fa-sticky-note"
+                    "fa_icon": "far fa-sticky-note",
+                    "pattern": "^[^\\n\\t\"]+$"
                 },
                 "metadata_7_header": {
                     "type": "string",
                     "default": "metadata_7",
                     "description": "The header name of metadata column 7.",
-                    "fa_icon": "far fa-sticky-note"
+                    "fa_icon": "far fa-sticky-note",
+                    "pattern": "^[^\\n\\t\"]+$"
                 },
                 "metadata_8_header": {
                     "type": "string",
                     "default": "metadata_8",
                     "description": "The header name of metadata column 8.",
-                    "fa_icon": "far fa-sticky-note"
+                    "fa_icon": "far fa-sticky-note",
+                    "pattern": "^[^\\n\\t\"]+$"
                 }
             },
             "fa_icon": "far fa-clipboard"
@@ -272,7 +283,14 @@
                     "description": "Method used to save pipeline results to output directory.",
                     "help_text": "The Nextflow `publishDir` option specifies which intermediate files should be saved to the output directory. This option tells the pipeline what method should be used to move these files. See [Nextflow docs](https://www.nextflow.io/docs/latest/process.html#publishdir) for details.",
                     "fa_icon": "fas fa-copy",
-                    "enum": ["symlink", "rellink", "link", "copy", "copyNoFollow", "move"],
+                    "enum": [
+                        "symlink",
+                        "rellink",
+                        "link",
+                        "copy",
+                        "copyNoFollow",
+                        "move"
+                    ],
                     "hidden": true
                 },
                 "email_on_fail": {

--- a/nextflow_schema.json
+++ b/nextflow_schema.json
@@ -55,15 +55,15 @@
                 },
                 "pd_missing_threshold": {
                     "type": "number",
-                    "default": 1
+                    "default": 1.0
                 },
                 "pd_sample_quality_threshold": {
                     "type": "number",
-                    "default": 1
+                    "default": 1.0
                 },
                 "pd_match_threshold": {
                     "type": "number",
-                    "default": -1
+                    "default": -1.0
                 },
                 "pd_file_type": {
                     "type": "string",
@@ -298,5 +298,39 @@
         {
             "$ref": "#/definitions/generic_options"
         }
-    ]
+    ],
+    "properties": {
+        "metadata_1_header": {
+            "type": "string",
+            "default": "metadata_1"
+        },
+        "metadata_2_header": {
+            "type": "string",
+            "default": "metadata_2"
+        },
+        "metadata_3_header": {
+            "type": "string",
+            "default": "metadata_3"
+        },
+        "metadata_4_header": {
+            "type": "string",
+            "default": "metadata_4"
+        },
+        "metadata_5_header": {
+            "type": "string",
+            "default": "metadata_5"
+        },
+        "metadata_6_header": {
+            "type": "string",
+            "default": "metadata_6"
+        },
+        "metadata_7_header": {
+            "type": "string",
+            "default": "metadata_7"
+        },
+        "metadata_8_header": {
+            "type": "string",
+            "default": "metadata_8"
+        }
+    }
 }

--- a/tests/data/append/expected_clusters_and_metadata.tsv
+++ b/tests/data/append/expected_clusters_and_metadata.tsv
@@ -1,0 +1,4 @@
+id	address	level_1	level_2	level_3	myheader_1	myheader_2	myheader_3	myheader_4	myheader_5	myheader_6	myheader_7	myheader_8
+sample1	1.1.1	1	1	1	1.1	1.2	1.3	1.4	1.5	1.6	1.7	1.8
+sample2	1.1.1	1	1	1	2.1	2.2	2.3	2.4	2.5	2.6	2.7	2.8
+sample3	2.2.2	2	2	2	3.1	3.2	3.3	3.4	3.5	3.6	3.7	3.8

--- a/tests/data/append/expected_clusters_and_metadata_little_metadata.tsv
+++ b/tests/data/append/expected_clusters_and_metadata_little_metadata.tsv
@@ -1,0 +1,4 @@
+id	address	level_1	level_2	level_3	metadata_1	metadata_2	metadata_3	metadata_4	metadata_5	metadata_6	metadata_7	metadata_8
+sample1	1.1.1	1	1	1				1.4				
+sample2	1.1.1	1	1	1								
+sample3	2.2.2	2	2	2	3.1	3.2						3.8

--- a/tests/data/append/expected_clusters_and_metadata_no_metadata.tsv
+++ b/tests/data/append/expected_clusters_and_metadata_no_metadata.tsv
@@ -1,0 +1,4 @@
+id	address	level_1	level_2	level_3	metadata_1	metadata_2	metadata_3	metadata_4	metadata_5	metadata_6	metadata_7	metadata_8
+sample1	1.1.1	1	1	1								
+sample2	1.1.1	1	1	1								
+sample3	2.2.2	2	2	2								

--- a/tests/data/samplesheets/samplesheet-little-metadata.csv
+++ b/tests/data/samplesheets/samplesheet-little-metadata.csv
@@ -1,0 +1,4 @@
+sample,mlst_alleles,metadata_1,metadata_2,metadata_3,metadata_4,metadata_5,metadata_6,metadata_7,metadata_8
+sample1,https://raw.githubusercontent.com/phac-nml/gasclustering/dev/tests/data/reports/sample1.mlst.json,,,,1.4,,,,
+sample2,https://raw.githubusercontent.com/phac-nml/gasclustering/dev/tests/data/reports/sample2.mlst.json,,,,,,,,
+sample3,https://raw.githubusercontent.com/phac-nml/gasclustering/dev/tests/data/reports/sample3.mlst.json,3.1,3.2,,,,,,3.8

--- a/tests/data/samplesheets/samplesheet-no-metadata.csv
+++ b/tests/data/samplesheets/samplesheet-no-metadata.csv
@@ -1,0 +1,4 @@
+sample,mlst_alleles,metadata_1,metadata_2,metadata_3,metadata_4,metadata_5,metadata_6,metadata_7,metadata_8
+sample1,https://raw.githubusercontent.com/phac-nml/gasclustering/dev/tests/data/reports/sample1.mlst.json,,,,,,,,
+sample2,https://raw.githubusercontent.com/phac-nml/gasclustering/dev/tests/data/reports/sample2.mlst.json,,,,,,,,
+sample3,https://raw.githubusercontent.com/phac-nml/gasclustering/dev/tests/data/reports/sample3.mlst.json,,,,,,,,

--- a/tests/data/samplesheets/samplesheet-tabs.csv
+++ b/tests/data/samplesheets/samplesheet-tabs.csv
@@ -1,0 +1,4 @@
+sample,mlst_alleles,metadata_1,metadata_2,metadata_3,metadata_4,metadata_5,metadata_6,metadata_7,metadata_8
+sample1,https://raw.githubusercontent.com/phac-nml/gasclustering/dev/tests/data/reports/sample1.mlst.json,a	b,,,,,,,
+sample2,https://raw.githubusercontent.com/phac-nml/gasclustering/dev/tests/data/reports/sample2.mlst.json,,,,a	b,,,,
+sample3,https://raw.githubusercontent.com/phac-nml/gasclustering/dev/tests/data/reports/sample3.mlst.json,,,,,,,,a	b

--- a/tests/data/samplesheets/samplesheet1.csv
+++ b/tests/data/samplesheets/samplesheet1.csv
@@ -1,4 +1,4 @@
-sample,mlst_alleles
-sample1,https://raw.githubusercontent.com/phac-nml/gasclustering/dev/tests/data/reports/sample1.mlst.json
-sample2,https://raw.githubusercontent.com/phac-nml/gasclustering/dev/tests/data/reports/sample2.mlst.json
-sample3,https://raw.githubusercontent.com/phac-nml/gasclustering/dev/tests/data/reports/sample3.mlst.json
+sample,mlst_alleles,metadata_1,metadata_2,metadata_3,metadata_4,metadata_5,metadata_6,metadata_7,metadata_8
+sample1,https://raw.githubusercontent.com/phac-nml/gasclustering/dev/tests/data/reports/sample1.mlst.json,1.1,1.2,1.3,1.4,1.5,1.6,1.7,1.8
+sample2,https://raw.githubusercontent.com/phac-nml/gasclustering/dev/tests/data/reports/sample2.mlst.json,2.1,2.2,2.3,2.4,2.5,2.6,2.7,2.8
+sample3,https://raw.githubusercontent.com/phac-nml/gasclustering/dev/tests/data/reports/sample3.mlst.json,3.1,3.2,3.3,3.4,3.5,3.6,3.7,3.8

--- a/tests/pipelines/main.nf.test
+++ b/tests/pipelines/main.nf.test
@@ -10,6 +10,15 @@ nextflow_pipeline {
             params {
                 input = "$baseDir/tests/data/samplesheets/samplesheet1.csv"
                 outdir = "results"
+
+                metadata_1_header = "myheader_1"
+                metadata_2_header = "myheader_2"
+                metadata_3_header = "myheader_3"
+                metadata_4_header = "myheader_4"
+                metadata_5_header = "myheader_5"
+                metadata_6_header = "myheader_6"
+                metadata_7_header = "myheader_7"
+                metadata_8_header = "myheader_8"
             }
         }
 
@@ -38,10 +47,23 @@ nextflow_pipeline {
             assert actual_tree.text == expected_tree.text
             assert actual_clusters.text ==  expected_clusters.text
 
+            // Check appended metadata is correct:
+            def actual_metadata = path("$launchDir/results/append/clusters_and_metadata.tsv")
+            assert actual_metadata.exists()
+            def expected_metadata = path("$baseDir/tests/data/append/expected_clusters_and_metadata.tsv")
+            assert actual_metadata.text == expected_metadata.text
 
             // Check that the ArborView output is created
             def actual_arbor_view = path("$launchDir/results/ArborView/clustered_data_arborview.html")
             assert actual_arbor_view.exists()
+            assert actual_arbor_view.text.contains("myheader_1")
+            assert actual_arbor_view.text.contains("1.1")
+            assert actual_arbor_view.text.contains("myheader_2")
+            assert actual_arbor_view.text.contains("2.2")
+            assert actual_arbor_view.text.contains("myheader_7")
+            assert actual_arbor_view.text.contains("3.7")
+            assert actual_arbor_view.text.contains("myheader_8")
+            assert actual_arbor_view.text.contains("1.8")
 
             // compare IRIDA Next JSON output
             def iridanext_json = path("$launchDir/results/iridanext.output.json").json

--- a/tests/pipelines/main.nf.test
+++ b/tests/pipelines/main.nf.test
@@ -65,4 +65,19 @@ nextflow_pipeline {
             def iridanext_metadata = iridanext_json.metadata.samples
         }
     }
+
+    test("Ensure failure because of metadata tabs") {
+        tag "pipeline"
+
+        when {
+            params {
+                input = "$baseDir/tests/data/samplesheets/samplesheet-tabs.csv"
+                outdir = "results"
+            }
+        }
+
+        then {
+            assert workflow.success == false
+        }
+    }
 }

--- a/tests/pipelines/main.nf.test
+++ b/tests/pipelines/main.nf.test
@@ -80,4 +80,112 @@ nextflow_pipeline {
             assert workflow.success == false
         }
     }
+
+    test("Full pipeline with no metadata") {
+        tag "pipeline"
+
+        when {
+            params {
+                input = "$baseDir/tests/data/samplesheets/samplesheet-no-metadata.csv"
+                outdir = "results"
+            }
+        }
+
+        then {
+            assert workflow.success
+            assert path("$launchDir/results").exists()
+
+            // Check MLST files
+            def actual_profile_tsv = path("$launchDir/results/merged/profile.tsv")
+            def expected_profile_tsv = path("$baseDir/tests/data/profiles/expected-profile1.tsv")
+            assert actual_profile_tsv.text == expected_profile_tsv.text
+
+            // Check computed distance matrix is correct and that the file exists
+            def actual_distances = path("$launchDir/results/distances/results.text")
+            assert actual_distances.exists()
+            def expected_distances = path("$baseDir/tests/data/distances/expected_dists.tsv")
+            assert actual_distances.text == expected_distances.text
+
+            // Check computed clusters are correct and exist
+            def actual_tree = path("$launchDir/results/clusters/tree.nwk")
+            def actual_clusters = path("$launchDir/results/clusters/clusters.text")
+            assert actual_tree.exists()
+            assert actual_clusters.exists()
+            def expected_tree = path("$baseDir/tests/data/clusters/expected_tree.nwk")
+            def expected_clusters = path("$baseDir/tests/data/clusters/expected_clusters.txt")
+            assert actual_tree.text == expected_tree.text
+            assert actual_clusters.text ==  expected_clusters.text
+
+            // Check appended metadata is correct:
+            def actual_metadata = path("$launchDir/results/append/clusters_and_metadata.tsv")
+            assert actual_metadata.exists()
+            def expected_metadata = path("$baseDir/tests/data/append/expected_clusters_and_metadata_no_metadata.tsv")
+            assert actual_metadata.text == expected_metadata.text
+
+            // Check that the ArborView output is created
+            def actual_arborview = path("$launchDir/results/ArborView/clustered_data_arborview.html")
+            assert actual_arborview.exists()
+            assert actual_arborview.text.contains("id\\taddress\\tlevel_1\\tlevel_2\\tlevel_3\\tmetadata_1\\tmetadata_2\\tmetadata_3\\tmetadata_4\\tmetadata_5\\tmetadata_6\\tmetadata_7\\tmetadata_8\\nsample1\\t1.1.1\\t1\\t1\\t1\\t\\t\\t\\t\\t\\t\\t\\t\\nsample2\\t1.1.1\\t1\\t1\\t1\\t\\t\\t\\t\\t\\t\\t\\t\\nsample3\\t2.2.2\\t2\\t2\\t2\\t\\t\\t\\t\\t\\t\\t\\t\\n")
+
+            // compare IRIDA Next JSON output
+            def iridanext_json = path("$launchDir/results/iridanext.output.json").json
+            def iridanext_global = iridanext_json.files.global
+            def iridanext_samples = iridanext_json.files.samples
+            def iridanext_metadata = iridanext_json.metadata.samples
+        }
+    }
+
+    test("Full pipeline with little metadata") {
+        tag "pipeline"
+
+        when {
+            params {
+                input = "$baseDir/tests/data/samplesheets/samplesheet-little-metadata.csv"
+                outdir = "results"
+            }
+        }
+
+        then {
+            assert workflow.success
+            assert path("$launchDir/results").exists()
+
+            // Check MLST files
+            def actual_profile_tsv = path("$launchDir/results/merged/profile.tsv")
+            def expected_profile_tsv = path("$baseDir/tests/data/profiles/expected-profile1.tsv")
+            assert actual_profile_tsv.text == expected_profile_tsv.text
+
+            // Check computed distance matrix is correct and that the file exists
+            def actual_distances = path("$launchDir/results/distances/results.text")
+            assert actual_distances.exists()
+            def expected_distances = path("$baseDir/tests/data/distances/expected_dists.tsv")
+            assert actual_distances.text == expected_distances.text
+
+            // Check computed clusters are correct and exist
+            def actual_tree = path("$launchDir/results/clusters/tree.nwk")
+            def actual_clusters = path("$launchDir/results/clusters/clusters.text")
+            assert actual_tree.exists()
+            assert actual_clusters.exists()
+            def expected_tree = path("$baseDir/tests/data/clusters/expected_tree.nwk")
+            def expected_clusters = path("$baseDir/tests/data/clusters/expected_clusters.txt")
+            assert actual_tree.text == expected_tree.text
+            assert actual_clusters.text ==  expected_clusters.text
+
+            // Check appended metadata is correct:
+            def actual_metadata = path("$launchDir/results/append/clusters_and_metadata.tsv")
+            assert actual_metadata.exists()
+            def expected_metadata = path("$baseDir/tests/data/append/expected_clusters_and_metadata_little_metadata.tsv")
+            assert actual_metadata.text == expected_metadata.text
+
+            // Check that the ArborView output is created
+            def actual_arborview = path("$launchDir/results/ArborView/clustered_data_arborview.html")
+            assert actual_arborview.exists()
+            assert actual_arborview.text.contains("id\\taddress\\tlevel_1\\tlevel_2\\tlevel_3\\tmetadata_1\\tmetadata_2\\tmetadata_3\\tmetadata_4\\tmetadata_5\\tmetadata_6\\tmetadata_7\\tmetadata_8\\nsample1\\t1.1.1\\t1\\t1\\t1\\t\\t\\t\\t1.4\\t\\t\\t\\t\\nsample2\\t1.1.1\\t1\\t1\\t1\\t\\t\\t\\t\\t\\t\\t\\t\\nsample3\\t2.2.2\\t2\\t2\\t2\\t3.1\\t3.2\\t\\t\\t\\t\\t\\t3.8\\n")
+
+            // compare IRIDA Next JSON output
+            def iridanext_json = path("$launchDir/results/iridanext.output.json").json
+            def iridanext_global = iridanext_json.files.global
+            def iridanext_samples = iridanext_json.files.samples
+            def iridanext_metadata = iridanext_json.metadata.samples
+        }
+    }
 }

--- a/tests/pipelines/main.nf.test
+++ b/tests/pipelines/main.nf.test
@@ -54,16 +54,9 @@ nextflow_pipeline {
             assert actual_metadata.text == expected_metadata.text
 
             // Check that the ArborView output is created
-            def actual_arbor_view = path("$launchDir/results/ArborView/clustered_data_arborview.html")
-            assert actual_arbor_view.exists()
-            assert actual_arbor_view.text.contains("myheader_1")
-            assert actual_arbor_view.text.contains("1.1")
-            assert actual_arbor_view.text.contains("myheader_2")
-            assert actual_arbor_view.text.contains("2.2")
-            assert actual_arbor_view.text.contains("myheader_7")
-            assert actual_arbor_view.text.contains("3.7")
-            assert actual_arbor_view.text.contains("myheader_8")
-            assert actual_arbor_view.text.contains("1.8")
+            def actual_arborview = path("$launchDir/results/ArborView/clustered_data_arborview.html")
+            assert actual_arborview.exists()
+            assert actual_arborview.text.contains("id\\taddress\\tlevel_1\\tlevel_2\\tlevel_3\\tmyheader_1\\tmyheader_2\\tmyheader_3\\tmyheader_4\\tmyheader_5\\tmyheader_6\\tmyheader_7\\tmyheader_8\\nsample1\\t1.1.1\\t1\\t1\\t1\\t1.1\\t1.2\\t1.3\\t1.4\\t1.5\\t1.6\\t1.7\\t1.8\\nsample2\\t1.1.1\\t1\\t1\\t1\\t2.1\\t2.2\\t2.3\\t2.4\\t2.5\\t2.6\\t2.7\\t2.8\\nsample3\\t2.2.2\\t2\\t2\\t2\\t3.1\\t3.2\\t3.3\\t3.4\\t3.5\\t3.6\\t3.7\\t3.8\\n")
 
             // compare IRIDA Next JSON output
             def iridanext_json = path("$launchDir/results/iridanext.output.json").json

--- a/workflows/gasclustering.nf
+++ b/workflows/gasclustering.nf
@@ -26,10 +26,11 @@ WorkflowGasclustering.initialise(params, log)
     IMPORT LOCAL MODULES/SUBWORKFLOWS
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 */
-include { LOCIDEX_MERGE } from '../modules/local/locidex/merge/main'
-include { PROFILE_DISTS } from '../modules/local/profile_dists/main'
-include { GAS_MCLUSTER  } from '../modules/local/gas/mcluster/main'
-include { ARBOR_VIEW  } from '../modules/local/arborview.nf'
+include { LOCIDEX_MERGE    } from '../modules/local/locidex/merge/main'
+include { PROFILE_DISTS    } from '../modules/local/profile_dists/main'
+include { GAS_MCLUSTER     } from '../modules/local/gas/mcluster/main'
+include { APPEND_METADATA  } from '../modules/local/appendmetadata/main'
+include { ARBOR_VIEW       } from '../modules/local/arborview.nf'
 
 /*
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -71,11 +72,32 @@ workflow GASCLUSTERING {
     // Create a new channel of metadata from a sample sheet
     // NB: `input` corresponds to `params.input` and associated sample sheet schema
     input = Channel.fromSamplesheet("input")
-    merged_input = input.map{
-        meta, mlst_files -> mlst_files
+
+    merged_alleles = input.map{
+        meta, mlst_files,
+        metadata_1, metadata_2, metadata_3, metadata_4,
+        metadata_5, metadata_6, metadata_7, metadata_8 -> mlst_files
     }.collect()
 
-    merged = LOCIDEX_MERGE(merged_input)
+    metadata_headers = Channel.of(
+        tuple(
+            params.metadata_1_header, params.metadata_2_header,
+            params.metadata_3_header, params.metadata_4_header,
+            params.metadata_5_header, params.metadata_6_header,
+            params.metadata_7_header, params.metadata_8_header)
+        )
+
+    metadata_rows = input.map{
+        meta, mlst_files,
+        metadata_1, metadata_2, metadata_3, metadata_4,
+        metadata_5, metadata_6, metadata_7, metadata_8 -> tuple(
+        metadata_1, metadata_2, metadata_3, metadata_4, 
+        metadata_5, metadata_6, metadata_7, metadata_8)
+    }
+    metadata_rows.view()
+    metadata = metadata_headers.concat(metadata_rows).toList()
+
+    merged = LOCIDEX_MERGE(merged_alleles)
     ch_versions = ch_versions.mix(merged.versions)
 
     // optional files passed in
@@ -88,7 +110,6 @@ workflow GASCLUSTERING {
     if(columns_file == null){
         exit 1, "${params.pd_columns}: Does not exist but was passed to the pipeline. Exiting now."
     }
-
 
     // Options related to profile dists
     mapping_format = Channel.value(params.pd_outfmt)
@@ -103,12 +124,11 @@ workflow GASCLUSTERING {
     it is simply a place holder showing how the module is intended to be used for later re-factoring
     */
 
-    tree_data = clustered_data.tree.merge(clustered_data.clusters) // mergeing as no not key to join on
+    data_and_metadata = APPEND_METADATA(clustered_data.clusters, metadata)
+    tree_data = clustered_data.tree.merge(data_and_metadata) // mergeing as no not key to join on
+
     tree_html = file(params.av_html)
     ARBOR_VIEW(tree_data, tree_html)
-
-
-
 
     CUSTOM_DUMPSOFTWAREVERSIONS (
         ch_versions.unique().collectFile(name: 'collated_versions.yml')

--- a/workflows/gasclustering.nf
+++ b/workflows/gasclustering.nf
@@ -94,7 +94,7 @@ workflow GASCLUSTERING {
         metadata_1, metadata_2, metadata_3, metadata_4, 
         metadata_5, metadata_6, metadata_7, metadata_8)
     }
-    metadata_rows.view()
+
     metadata = metadata_headers.concat(metadata_rows).toList()
 
     merged = LOCIDEX_MERGE(merged_alleles)

--- a/workflows/gasclustering.nf
+++ b/workflows/gasclustering.nf
@@ -90,12 +90,10 @@ workflow GASCLUSTERING {
     metadata_rows = input.map{
         meta, mlst_files,
         metadata_1, metadata_2, metadata_3, metadata_4,
-        metadata_5, metadata_6, metadata_7, metadata_8 -> tuple(
+        metadata_5, metadata_6, metadata_7, metadata_8 -> tuple(meta.id,
         metadata_1, metadata_2, metadata_3, metadata_4,
         metadata_5, metadata_6, metadata_7, metadata_8)
-    }
-
-    metadata = metadata_headers.concat(metadata_rows).toList()
+    }.toList()
 
     merged = LOCIDEX_MERGE(merged_alleles)
     ch_versions = ch_versions.mix(merged.versions)
@@ -124,7 +122,7 @@ workflow GASCLUSTERING {
     it is simply a place holder showing how the module is intended to be used for later re-factoring
     */
 
-    data_and_metadata = APPEND_METADATA(clustered_data.clusters, metadata)
+    data_and_metadata = APPEND_METADATA(clustered_data.clusters, metadata_rows, metadata_headers)
     tree_data = clustered_data.tree.merge(data_and_metadata) // mergeing as no key to join on
 
     tree_html = file(params.av_html)

--- a/workflows/gasclustering.nf
+++ b/workflows/gasclustering.nf
@@ -91,7 +91,7 @@ workflow GASCLUSTERING {
         meta, mlst_files,
         metadata_1, metadata_2, metadata_3, metadata_4,
         metadata_5, metadata_6, metadata_7, metadata_8 -> tuple(
-        metadata_1, metadata_2, metadata_3, metadata_4, 
+        metadata_1, metadata_2, metadata_3, metadata_4,
         metadata_5, metadata_6, metadata_7, metadata_8)
     }
 

--- a/workflows/gasclustering.nf
+++ b/workflows/gasclustering.nf
@@ -74,9 +74,7 @@ workflow GASCLUSTERING {
     input = Channel.fromSamplesheet("input")
 
     merged_alleles = input.map{
-        meta, mlst_files,
-        metadata_1, metadata_2, metadata_3, metadata_4,
-        metadata_5, metadata_6, metadata_7, metadata_8 -> mlst_files
+        meta, mlst_files -> mlst_files
     }.collect()
 
     metadata_headers = Channel.of(
@@ -88,11 +86,9 @@ workflow GASCLUSTERING {
         )
 
     metadata_rows = input.map{
-        meta, mlst_files,
-        metadata_1, metadata_2, metadata_3, metadata_4,
-        metadata_5, metadata_6, metadata_7, metadata_8 -> tuple(meta.id,
-        metadata_1, metadata_2, metadata_3, metadata_4,
-        metadata_5, metadata_6, metadata_7, metadata_8)
+        meta, mlst_files -> tuple(meta.id,
+        meta.metadata_1, meta.metadata_2, meta.metadata_3, meta.metadata_4,
+        meta.metadata_5, meta.metadata_6, meta.metadata_7, meta.metadata_8)
     }.toList()
 
     merged = LOCIDEX_MERGE(merged_alleles)


### PR DESCRIPTION
Adds support for metadata:

- Adds 8 fixed columns that can be renamed with `metadata_1_header` through `metadata_8_header` headers.
- Adds a module that opens up the TSV-formatted cluster file and appends metadata provided through the samplesheet.
- Passes the appended TSV-formatted cluster file to ArborView.

Tested on Azure and it works, but requires manually specifying `"av_html":"https://github.com/phac-nml/gasclustering/raw/dev/assets/ArborView.html"` as discussed.