### PR TITLE
Removing ArborView as a Parameter for Azure Compatibility

### DIFF
--- a/nextflow.config
+++ b/nextflow.config
@@ -60,10 +60,6 @@ params {
     gm_thresholds = "10,5,0"
     gm_delimiter = "."
 
-    // Arborview specific data
-    // TODO check this works in azure
-    av_html = "./assets/ArborView.html"
-
     // Metadata
     metadata_1_header = "metadata_1"
     metadata_2_header = "metadata_2"

--- a/nextflow_schema.json
+++ b/nextflow_schema.json
@@ -120,15 +120,15 @@
                 },
                 "pd_missing_threshold": {
                     "type": "number",
-                    "default": 1
+                    "default": 1.0
                 },
                 "pd_sample_quality_threshold": {
                     "type": "number",
-                    "default": 1
+                    "default": 1.0
                 },
                 "pd_match_threshold": {
                     "type": "number",
-                    "default": -1
+                    "default": -1.0
                 },
                 "pd_file_type": {
                     "type": "string",
@@ -171,19 +171,6 @@
                     "type": "string",
                     "default": ".",
                     "pattern": "^\\S+$"
-                }
-            }
-        },
-        "arborview": {
-            "title": "ArborView",
-            "type": "object",
-            "description": "",
-            "default": "",
-            "properties": {
-                "av_html": {
-                    "type": "string",
-                    "default": "./assets/ArborView.html",
-                    "hidden": true
                 }
             }
         },
@@ -353,9 +340,6 @@
         },
         {
             "$ref": "#/definitions/gas_cluster"
-        },
-        {
-            "$ref": "#/definitions/arborview"
         },
         {
             "$ref": "#/definitions/institutional_config_options"

--- a/tests/nextflow.config
+++ b/tests/nextflow.config
@@ -6,7 +6,6 @@
 
 params.max_memory = "2.GB"
 params.max_cpus = 1
-params.av_html = "$baseDir/assets/ArborView.html"
 
 /* This is required to run in WSL/Ubuntu using singularity
 Without this, profile_dists was not successfully completing

--- a/workflows/gasclustering.nf
+++ b/workflows/gasclustering.nf
@@ -121,7 +121,7 @@ workflow GASCLUSTERING {
     data_and_metadata = APPEND_METADATA(clustered_data.clusters, metadata_rows, metadata_headers)
     tree_data = clustered_data.tree.merge(data_and_metadata) // mergeing as no key to join on
 
-    tree_html = file(params.av_html)
+    tree_html = file("$projectDir/assets/ArborView.html")
     ARBOR_VIEW(tree_data, tree_html)
 
     CUSTOM_DUMPSOFTWAREVERSIONS (


### PR DESCRIPTION
Removed ArborView as a parameter and follows the same strategy for referencing `asset/` files that's already used by nf-core's `email_template.html` [here](https://github.com/phac-nml/gasclustering/blob/dev/lib/NfcoreTemplate.groovy):

`new File("$projectDir/assets/email_template.html")`

This should make it compatible with Azure, as the path isn't being loaded in a from a parameter (which won't be handled correctly by the Azure plugin).

