### PR TITLE
Update/input assure to accommodate changes in locidex mlst.json allele reports 

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -56,4 +56,4 @@ jobs:
 
       - name: Nextflow run with test profile
         run: |
-          nextflow run ${GITHUB_WORKSPACE} -profile test,docker --outdir ./results
+          nextflow run ${GITHUB_WORKSPACE} -profile test,docker --outdir ./results -with-docker -user $(id -u):$(id -g)

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -56,4 +56,4 @@ jobs:
 
       - name: Nextflow run with test profile
         run: |
-          nextflow run ${GITHUB_WORKSPACE} -profile test,docker --outdir ./results -with-docker --user 1001
+          nextflow run ${GITHUB_WORKSPACE} -profile test,docker --outdir ./results

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -56,4 +56,4 @@ jobs:
 
       - name: Nextflow run with test profile
         run: |
-          nextflow run ${GITHUB_WORKSPACE} -profile test,docker --outdir ./results
+          nextflow run ${GITHUB_WORKSPACE} -profile test,docker --outdir ./results -with-docker --user $(id -u):$(id -g)

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -56,4 +56,4 @@ jobs:
 
       - name: Nextflow run with test profile
         run: |
-          nextflow run ${GITHUB_WORKSPACE} -profile test,docker --outdir ./results -with-docker --user $(id -u):$(id -g)
+          nextflow run ${GITHUB_WORKSPACE} -profile test,docker --outdir ./results -with-docker --user 1001

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -56,4 +56,4 @@ jobs:
 
       - name: Nextflow run with test profile
         run: |
-          nextflow run ${GITHUB_WORKSPACE} -profile test,docker --outdir ./results -with-docker -user $(id -u):$(id -g)
+          nextflow run ${GITHUB_WORKSPACE} -profile test,docker --outdir ./results -with-docker -user root

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -56,4 +56,4 @@ jobs:
 
       - name: Nextflow run with test profile
         run: |
-          nextflow run ${GITHUB_WORKSPACE} -profile test,docker --outdir ./results -with-docker -user root
+          nextflow run ${GITHUB_WORKSPACE} -profile test,docker --outdir ./results

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased] - 2024-08-20
+## [0.3.0] - 2024-08-21
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,3 +37,4 @@ Initial release of the Genomic Address Service Clustering pipeline to be used fo
 
 [0.1.0]: https://github.com/phac-nml/gasclustering/releases/tag/0.1.0
 [0.2.0]: https://github.com/phac-nml/gasclustering/releases/tag/0.2.0
+[0.3.0]: https://github.com/phac-nml/gasclustering/releases/tag/0.3.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,15 @@
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased] - 2024-08-20
+
+### Changed
+
+- Upgraded `locidex/merge` to version `0.2.2` and updated `input_assure` and test data for compatibility with the new `mlst.json` allele file format.
+  - [PR28](https://github.com/phac-nml/gasclustering/pull/28)
+- Aligned container registry handling in configuration files and modules with `phac-nml/pipeline-standards`
+  - [PR28](https://github.com/phac-nml/gasclustering/pull/28)
+
 ## [0.2.0] - 2024-06-26
 
 ### Added

--- a/assets/samplesheet.csv
+++ b/assets/samplesheet.csv
@@ -1,4 +1,4 @@
 sample,mlst_alleles
-sample1,/root/working_directory/nml-phac/gasclustering/tests/data/reports/sample1.mlst.json
-sample2,/root/working_directory/nml-phac/gasclustering/tests/data/reports/sample2.mlst.json
-sample3,/root/working_directory/nml-phac/gasclustering/tests/data/reports/sample3.mlst.json
+sample1,https://raw.githubusercontent.com/phac-nml/gasclustering/update/input_assure/tests/data/reports/sample1.mlst.json
+sample2,https://raw.githubusercontent.com/phac-nml/gasclustering/update/input_assure/tests/data/reports/sample2.mlst.json
+sample3,https://raw.githubusercontent.com/phac-nml/gasclustering/update/input_assure/tests/data/reports/sample3.mlst.json

--- a/assets/samplesheet.csv
+++ b/assets/samplesheet.csv
@@ -1,4 +1,4 @@
 sample,mlst_alleles
-sample1,https://raw.githubusercontent.com/phac-nml/gasclustering/dev/tests/data/reports/sample1.mlst.json
-sample2,https://raw.githubusercontent.com/phac-nml/gasclustering/dev/tests/data/reports/sample2.mlst.json
-sample3,https://raw.githubusercontent.com/phac-nml/gasclustering/dev/tests/data/reports/sample3.mlst.json
+sample1,/root/working_directory/nml-phac/gasclustering/tests/data/reports/sample1.mlst.json
+sample2,/root/working_directory/nml-phac/gasclustering/tests/data/reports/sample2.mlst.json
+sample3,/root/working_directory/nml-phac/gasclustering/tests/data/reports/sample3.mlst.json

--- a/bin/input_assure.py
+++ b/bin/input_assure.py
@@ -19,18 +19,24 @@ def check_inputs(json_file, sample_id, address, output_error_file, output_json_f
     with open_file(json_file, "rt") as f:
         json_data = json.load(f)
 
+    print(json.dumps(json_data, indent=4))
+
+    # Extract the profile from the json_data
+    profile = json_data.get("data", {}).get("profile", {})
+    # Check for multiple keys in the JSON file and define error message
+    keys = list(profile.keys())
+    original_key = keys[0] if keys else None
+
     # Define a variable to store the match_status (True or False)
-    match_status = sample_id in json_data
+    match_status = sample_id in profile
 
     # Initialize the error message
     error_message = None
 
-    # Check for multiple keys in the JSON file and define error message
-    keys = list(json_data.keys())
-    original_key = keys[0] if keys else None
-
-    if len(keys) == 0:
-        error_message = f"{json_file} is completely empty!"
+    if not keys:
+        error_message = (
+            f"{json_file} is missing the 'profile' section or is completely empty!"
+        )
         print(error_message)
         sys.exit(1)
     elif len(keys) > 1:
@@ -38,11 +44,11 @@ def check_inputs(json_file, sample_id, address, output_error_file, output_json_f
         if not match_status:
             error_message = f"No key in the MLST JSON file ({json_file}) matches the specified sample ID '{sample_id}'. The first key '{original_key}' has been forcefully changed to '{sample_id}' and all other keys have been removed."
             # Retain only the specified sample ID
-            json_data = {sample_id: json_data.pop(original_key)}
+            json_data["data"]["profile"] = {sample_id: profile.pop(original_key)}
         else:
             error_message = f"MLST JSON file ({json_file}) contains multiple keys: {keys}. The MLST JSON file has been modified to retain only the '{sample_id}' entry"
-            # Remove all keys expect the one matching sample_id
-            json_data = {sample_id: json_data[sample_id]}
+            # Retain only the specified sample_id in the profile
+            json_data["data"]["profile"] = {sample_id: profile[sample_id]}
     elif not match_status:
         # Define error message based on meta.address (query or reference)
         if address == "null":
@@ -50,7 +56,8 @@ def check_inputs(json_file, sample_id, address, output_error_file, output_json_f
         else:
             error_message = f"Reference {sample_id} ID and JSON key in {json_file} DO NOT MATCH. The '{original_key}' key in {json_file} has been forcefully changed to '{sample_id}': User should manually check input files to ensure correctness."
         # Update the JSON file with the new sample ID
-        json_data[sample_id] = json_data.pop(original_key)
+        json_data["data"]["profile"] = {sample_id: profile.pop(original_key)}
+        json_data["data"]["sample_name"] = sample_id
 
     # Write file containing relevant error messages
     if error_message:

--- a/bin/input_assure.py
+++ b/bin/input_assure.py
@@ -19,8 +19,6 @@ def check_inputs(json_file, sample_id, address, output_error_file, output_json_f
     with open_file(json_file, "rt") as f:
         json_data = json.load(f)
 
-    print(json.dumps(json_data, indent=4))
-
     # Extract the profile from the json_data
     profile = json_data.get("data", {}).get("profile", {})
     # Check for multiple keys in the JSON file and define error message

--- a/bin/input_assure.py
+++ b/bin/input_assure.py
@@ -22,7 +22,7 @@ def check_inputs(json_file, sample_id, address, output_error_file, output_json_f
     # Extract the profile from the json_data
     profile = json_data.get("data", {}).get("profile", {})
     # Check for multiple keys in the JSON file and define error message
-    keys = list(profile.keys())
+    keys = sorted(profile.keys())
     original_key = keys[0] if keys else None
 
     # Define a variable to store the match_status (True or False)

--- a/conf/modules.config
+++ b/conf/modules.config
@@ -48,7 +48,6 @@ process {
             saveAs: { filename -> filename.equals('versions.yml') ? null :
             filename.contains(File.separator) ? task.merged_prefix + filename.split(File.separator)[-1] : task.merged_prefix + filename }
         ]
-        containerOptions = '--user $(id -u):$(id -g)'
     }
 
     withName: PROFILE_DISTS {

--- a/conf/modules.config
+++ b/conf/modules.config
@@ -48,6 +48,7 @@ process {
             saveAs: { filename -> filename.equals('versions.yml') ? null :
             filename.contains(File.separator) ? task.merged_prefix + filename.split(File.separator)[-1] : task.merged_prefix + filename }
         ]
+        containerOptions = '--user $(id -u):$(id -g)'
     }
 
     withName: PROFILE_DISTS {

--- a/conf/test.config
+++ b/conf/test.config
@@ -20,7 +20,7 @@ params {
     max_time   = '1.h'
 
     // Input data
-    input  = 'https://raw.githubusercontent.com/phac-nml/gasclustering/dev/assets/samplesheet.csv'
+    input  = "${projectDir}/assets/samplesheet.csv"
 }
 
 

--- a/modules/local/arborview.nf
+++ b/modules/local/arborview.nf
@@ -9,9 +9,8 @@ process ARBOR_VIEW {
     stageInMode 'copy' // Need to copy in arbor view html
 
     container "${ workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ?
-    "docker.io/python:3.11.6" :
-    task.ext.override_configured_container_registry != false ? 'docker.io/python:3.11.6' :
-    'python:3.11.6' }"
+    'https://depot.galaxyproject.org/singularity/python%3A3.12' :
+    'biocontainers/python:3.12' }"
 
     input:
     tuple path(tree), path(contextual_data)

--- a/modules/local/arborview.nf
+++ b/modules/local/arborview.nf
@@ -10,7 +10,8 @@ process ARBOR_VIEW {
 
     container "${ workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ?
     "docker.io/python:3.11.6" :
-    "docker.io/python:3.11.6" }"
+    task.ext.override_configured_container_registry != false ? 'docker.io/python:3.11.6' :
+    'python:3.11.6' }"
 
     input:
     tuple path(tree), path(contextual_data)

--- a/modules/local/gas/mcluster/main.nf
+++ b/modules/local/gas/mcluster/main.nf
@@ -6,7 +6,7 @@ process GAS_MCLUSTER{
 
     container "${ workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ?
         'https://depot.galaxyproject.org/singularity/genomic_address_service%3A0.1.1--pyh7cba7a3_1' :
-        'quay.io/biocontainers/genomic_address_service:0.1.1--pyh7cba7a3_1' }"
+        'biocontainers/genomic_address_service:0.1.1--pyh7cba7a3_1' }"
 
     input:
     path(dist_matrix)

--- a/modules/local/locidex/merge/main.nf
+++ b/modules/local/locidex/merge/main.nf
@@ -5,8 +5,9 @@ process LOCIDEX_MERGE {
     label 'process_medium'
 
     container "${ workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ?
-    'docker.io/mwells14/locidex:0.2.2' :
-    'docker.io/mwells14/locidex:0.2.2' }"
+    "docker.io/mwells14/locidex:0.2.2" :
+    task.ext.override_configured_container_registry != false ? 'docker.io/mwells14/locidex:0.2.2' :
+    'mwells14/locidex:0.2.2' }"
 
     input:
     path input_values // [file(sample1), file(sample2), file(sample3), etc...]

--- a/modules/local/locidex/merge/main.nf
+++ b/modules/local/locidex/merge/main.nf
@@ -5,9 +5,9 @@ process LOCIDEX_MERGE {
     label 'process_medium'
 
     container "${ workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ?
-    "docker.io/mwells14/locidex:0.2.2" :
-    task.ext.override_configured_container_registry != false ? 'docker.io/mwells14/locidex:0.2.2' :
-    'mwells14/locidex:0.2.2' }"
+    "docker.io/mwells14/locidex:0.2.3" :
+    task.ext.override_configured_container_registry != false ? 'docker.io/mwells14/locidex:0.2.3' :
+    'mwells14/locidex:0.2.3' }"
 
     input:
     path input_values // [file(sample1), file(sample2), file(sample3), etc...]

--- a/modules/local/locidex/merge/main.nf
+++ b/modules/local/locidex/merge/main.nf
@@ -5,8 +5,8 @@ process LOCIDEX_MERGE {
     label 'process_medium'
 
     container "${ workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ?
-    'https://depot.galaxyproject.org/singularity/locidex:0.1.1--pyhdfd78af_0' :
-    'quay.io/biocontainers/locidex:0.1.1--pyhdfd78af_0' }"
+    'docker.io/mwells14/locidex:0.2.2' :
+    'docker.io/mwells14/locidex:0.2.2' }"
 
     input:
     path input_values // [file(sample1), file(sample2), file(sample3), etc...]

--- a/modules/local/profile_dists/main.nf
+++ b/modules/local/profile_dists/main.nf
@@ -4,7 +4,8 @@ process PROFILE_DISTS{
 
     container "${ workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ?
         'docker.io/mwells14/gsp:arborator_1.0.0' :
-        'docker.io/mwells14/gsp:arborator_1.0.0' }"
+        task.ext.override_configured_container_registry != false ? 'docker.io/mwells14/gsp:arborator_1.0.0' :
+        'mwells14/gsp:arborator_1.0.0' }"
 
     input:
     path query

--- a/nextflow.config
+++ b/nextflow.config
@@ -178,6 +178,9 @@ docker.registry      = 'quay.io'
 podman.registry      = 'quay.io'
 singularity.registry = 'quay.io'
 
+// Override the default Docker registry when required
+process.ext.override_configured_container_registry = true
+
 // Nextflow plugins
 plugins {
     id 'nf-validation@1.1.3' // Validation of pipeline parameters and creation of an input channel from a sample sheet

--- a/nextflow.config
+++ b/nextflow.config
@@ -229,7 +229,7 @@ manifest {
     description     = """IRIDA Next Genomic Address Service Clustering Pipeline"""
     mainScript      = 'main.nf'
     nextflowVersion = '!>=23.04.0'
-    version         = '0.2.0'
+    version         = '0.3.0'
     doi             = ''
     defaultBranch   = 'main'
 }

--- a/tests/data/reports/case-hamming/sample1.mlst.subtyping.json
+++ b/tests/data/reports/case-hamming/sample1.mlst.subtyping.json
@@ -1,7 +1,21 @@
 {
-    "sample1": {
-        "l1": "1",
-        "l2": "1",
-        "l3": "1"
+    "db_info": {},
+    "parameters": {
+        "mode": "normal",
+        "min_match_ident": 100,
+        "min_match_cov": 100,
+        "max_ambiguous": 0,
+        "max_internal_stops": 0
+    },
+    "data": {
+        "sample_name": "sample1",
+        "profile": {
+            "sample1": {
+                "l1": "1",
+                "l2": "1",
+                "l3": "1"
+            }
+        },
+        "seq_data": {}
     }
 }

--- a/tests/data/reports/case-hamming/sample2.mlst.subtyping.json
+++ b/tests/data/reports/case-hamming/sample2.mlst.subtyping.json
@@ -1,7 +1,21 @@
 {
-    "sample2": {
-        "l1": "1",
-        "l2": "2",
-        "l3": "1"
+    "db_info": {},
+    "parameters": {
+        "mode": "normal",
+        "min_match_ident": 100,
+        "min_match_cov": 100,
+        "max_ambiguous": 0,
+        "max_internal_stops": 0
+    },
+    "data": {
+        "sample_name": "sample2",
+        "profile": {
+            "sample2": {
+                "l1": "1",
+                "l2": "2",
+                "l3": "1"
+            }
+        },
+        "seq_data": {}
     }
 }

--- a/tests/data/reports/case-hamming/sample3.mlst.subtyping.json
+++ b/tests/data/reports/case-hamming/sample3.mlst.subtyping.json
@@ -1,7 +1,21 @@
 {
-    "sample3": {
-        "l1": "2",
-        "l2": "1",
-        "l3": "2"
+    "db_info": {},
+    "parameters": {
+        "mode": "normal",
+        "min_match_ident": 100,
+        "min_match_cov": 100,
+        "max_ambiguous": 0,
+        "max_internal_stops": 0
+    },
+    "data": {
+        "sample_name": "sample3",
+        "profile": {
+            "sample3": {
+                "l1": "2",
+                "l2": "1",
+                "l3": "2"
+            }
+        },
+        "seq_data": {}
     }
 }

--- a/tests/data/reports/case-hash-missing/sample1.mlst.subtyping.json
+++ b/tests/data/reports/case-hash-missing/sample1.mlst.subtyping.json
@@ -1,7 +1,21 @@
 {
-    "sample1": {
-        "l1": "b026324c6904b2a9cb4b88d6d61c81d1",
-        "l2": "b026324c6904b2a9cb4b88d6d61c81d1",
-        "l3": "b026324c6904b2a9cb4b88d6d61c81d1"
+    "db_info": {},
+    "parameters": {
+        "mode": "normal",
+        "min_match_ident": 100,
+        "min_match_cov": 100,
+        "max_ambiguous": 0,
+        "max_internal_stops": 0
+    },
+    "data": {
+        "sample_name": "sample1",
+        "profile": {
+            "sample1": {
+                "l1": "b026324c6904b2a9cb4b88d6d61c81d1",
+                "l2": "b026324c6904b2a9cb4b88d6d61c81d1",
+                "l3": "b026324c6904b2a9cb4b88d6d61c81d1"
+            }
+        },
+        "seq_data": {}
     }
 }

--- a/tests/data/reports/case-hash-missing/sample2.mlst.subtyping.json
+++ b/tests/data/reports/case-hash-missing/sample2.mlst.subtyping.json
@@ -1,7 +1,21 @@
 {
-    "sample2": {
-        "l1": "-",
-        "l2": "26ab0db90d72e28ad0ba1e22ee510510",
-        "l3": "b026324c6904b2a9cb4b88d6d61c81d1"
+    "db_info": {},
+    "parameters": {
+        "mode": "normal",
+        "min_match_ident": 100,
+        "min_match_cov": 100,
+        "max_ambiguous": 0,
+        "max_internal_stops": 0
+    },
+    "data": {
+        "sample_name": "sample2",
+        "profile": {
+            "sample2": {
+                "l1": "-",
+                "l2": "26ab0db90d72e28ad0ba1e22ee510510",
+                "l3": "b026324c6904b2a9cb4b88d6d61c81d1"
+            }
+        },
+        "seq_data": {}
     }
 }

--- a/tests/data/reports/case-hash-missing/sample3-more-missing.mlst.subtyping.json
+++ b/tests/data/reports/case-hash-missing/sample3-more-missing.mlst.subtyping.json
@@ -1,7 +1,21 @@
 {
-    "sample3": {
-        "l1": "-",
-        "l2": "-",
-        "l3": "26ab0db90d72e28ad0ba1e22ee510510"
+    "db_info": {},
+    "parameters": {
+        "mode": "normal",
+        "min_match_ident": 100,
+        "min_match_cov": 100,
+        "max_ambiguous": 0,
+        "max_internal_stops": 0
+    },
+    "data": {
+        "sample_name": "sample3",
+        "profile": {
+            "sample3": {
+                "l1": "-",
+                "l2": "-",
+                "l3": "26ab0db90d72e28ad0ba1e22ee510510"
+            }
+        },
+        "seq_data": {}
     }
 }

--- a/tests/data/reports/case-hash-missing/sample3.mlst.subtyping.json
+++ b/tests/data/reports/case-hash-missing/sample3.mlst.subtyping.json
@@ -1,7 +1,21 @@
 {
-    "sample3": {
-        "l1": "-",
-        "l2": "b026324c6904b2a9cb4b88d6d61c81d1",
-        "l3": "26ab0db90d72e28ad0ba1e22ee510510"
+    "db_info": {},
+    "parameters": {
+        "mode": "normal",
+        "min_match_ident": 100,
+        "min_match_cov": 100,
+        "max_ambiguous": 0,
+        "max_internal_stops": 0
+    },
+    "data": {
+        "sample_name": "sample3",
+        "profile": {
+            "sample3": {
+                "l1": "-",
+                "l2": "b026324c6904b2a9cb4b88d6d61c81d1",
+                "l3": "26ab0db90d72e28ad0ba1e22ee510510"
+            }
+        },
+        "seq_data": {}
     }
 }

--- a/tests/data/reports/sample1.mlst.json
+++ b/tests/data/reports/sample1.mlst.json
@@ -1,7 +1,21 @@
 {
-    "sample1": {
-        "l1": "1",
-        "l2": "1",
-        "l3": "1"
+    "db_info": {},
+    "parameters": {
+        "mode": "normal",
+        "min_match_ident": 100,
+        "min_match_cov": 100,
+        "max_ambiguous": 0,
+        "max_internal_stops": 0
+    },
+    "data": {
+        "sample_name": "sample1",
+        "profile": {
+            "sample1": {
+                "l1": "1",
+                "l2": "1",
+                "l3": "1"
+            }
+        },
+        "seq_data": {}
     }
 }

--- a/tests/data/reports/sample2.mlst.json
+++ b/tests/data/reports/sample2.mlst.json
@@ -1,7 +1,21 @@
 {
-    "sample2": {
-        "l1": "1",
-        "l2": "1",
-        "l3": "1"
+    "db_info": {},
+    "parameters": {
+        "mode": "normal",
+        "min_match_ident": 100,
+        "min_match_cov": 100,
+        "max_ambiguous": 0,
+        "max_internal_stops": 0
+    },
+    "data": {
+        "sample_name": "sample2",
+        "profile": {
+            "sample2": {
+                "l1": "1",
+                "l2": "1",
+                "l3": "1"
+            }
+        },
+        "seq_data": {}
     }
 }

--- a/tests/data/reports/sample3.mlst.json
+++ b/tests/data/reports/sample3.mlst.json
@@ -1,7 +1,21 @@
 {
-    "sample3": {
-        "l1": "1",
-        "l2": "1",
-        "l3": "2"
+    "db_info": {},
+    "parameters": {
+        "mode": "normal",
+        "min_match_ident": 100,
+        "min_match_cov": 100,
+        "max_ambiguous": 0,
+        "max_internal_stops": 0
+    },
+    "data": {
+        "sample_name": "sample3",
+        "profile": {
+            "sample3": {
+                "l1": "1",
+                "l2": "1",
+                "l3": "2"
+            }
+        },
+        "seq_data": {}
     }
 }

--- a/tests/data/samplesheets/samplesheet-hamming.csv
+++ b/tests/data/samplesheets/samplesheet-hamming.csv
@@ -1,4 +1,4 @@
 sample,mlst_alleles,metadata_1,metadata_2,metadata_3,metadata_4,metadata_5,metadata_6,metadata_7,metadata_8
 sample1,https://raw.githubusercontent.com/phac-nml/gasclustering/update/input_assure/tests/data/reports/case-hamming/sample1.mlst.subtyping.json,,,,,,,,
-sample2,https://raw.githubusercontent.com/phac-nml/gasclustering/update/input_assure/tests/data/reports/case-hamming/sample3.mlst.subtyping.json,,,,,,,,
+sample2,https://raw.githubusercontent.com/phac-nml/gasclustering/update/input_assure/tests/data/reports/case-hamming/sample2.mlst.subtyping.json,,,,,,,,
 sample3,https://raw.githubusercontent.com/phac-nml/gasclustering/update/input_assure/tests/data/reports/case-hamming/sample3.mlst.subtyping.json,,,,,,,,

--- a/tests/data/samplesheets/samplesheet-hamming.csv
+++ b/tests/data/samplesheets/samplesheet-hamming.csv
@@ -1,4 +1,4 @@
 sample,mlst_alleles,metadata_1,metadata_2,metadata_3,metadata_4,metadata_5,metadata_6,metadata_7,metadata_8
 sample1,https://raw.githubusercontent.com/phac-nml/gasclustering/update/input_assure/tests/data/reports/case-hamming/sample1.mlst.subtyping.json,,,,,,,,
-sample2,https://raw.githubusercontent.com/phac-nml/gasclustering/dev/tests/update/input_assure/reports/case-hamming/sample2.mlst.subtyping.json,,,,,,,,
-sample3,https://raw.githubusercontent.com/phac-nml/gasclustering/dev/tests/update/input_assure/reports/case-hamming/sample3.mlst.subtyping.json,,,,,,,,
+sample2,https://raw.githubusercontent.com/phac-nml/gasclustering/update/input_assure/tests/data/reports/case-hamming/sample3.mlst.subtyping.json,,,,,,,,
+sample3,https://raw.githubusercontent.com/phac-nml/gasclustering/update/input_assure/tests/data/reports/case-hamming/sample3.mlst.subtyping.json,,,,,,,,

--- a/tests/data/samplesheets/samplesheet-hamming.csv
+++ b/tests/data/samplesheets/samplesheet-hamming.csv
@@ -1,4 +1,4 @@
 sample,mlst_alleles,metadata_1,metadata_2,metadata_3,metadata_4,metadata_5,metadata_6,metadata_7,metadata_8
-sample1,https://raw.githubusercontent.com/phac-nml/gasclustering/dev/tests/data/reports/case-hamming/sample1.mlst.subtyping.json,,,,,,,,
-sample2,https://raw.githubusercontent.com/phac-nml/gasclustering/dev/tests/data/reports/case-hamming/sample2.mlst.subtyping.json,,,,,,,,
-sample3,https://raw.githubusercontent.com/phac-nml/gasclustering/dev/tests/data/reports/case-hamming/sample3.mlst.subtyping.json,,,,,,,,
+sample1,https://raw.githubusercontent.com/phac-nml/gasclustering/update/input_assure/tests/data/reports/case-hamming/sample1.mlst.subtyping.json,,,,,,,,
+sample2,https://raw.githubusercontent.com/phac-nml/gasclustering/dev/tests/update/input_assure/reports/case-hamming/sample2.mlst.subtyping.json,,,,,,,,
+sample3,https://raw.githubusercontent.com/phac-nml/gasclustering/dev/tests/update/input_assure/reports/case-hamming/sample3.mlst.subtyping.json,,,,,,,,

--- a/tests/data/samplesheets/samplesheet-hash-missing.csv
+++ b/tests/data/samplesheets/samplesheet-hash-missing.csv
@@ -1,4 +1,4 @@
 sample,mlst_alleles,metadata_1,metadata_2,metadata_3,metadata_4,metadata_5,metadata_6,metadata_7,metadata_8
-sample1,https://raw.githubusercontent.com/phac-nml/gasclustering/dev/tests/data/reports/case-hash-missing/sample1.mlst.subtyping.json,,,,,,,,
-sample2,https://raw.githubusercontent.com/phac-nml/gasclustering/dev/tests/data/reports/case-hash-missing/sample2.mlst.subtyping.json,,,,,,,,
-sample3,https://raw.githubusercontent.com/phac-nml/gasclustering/dev/tests/data/reports/case-hash-missing/sample3.mlst.subtyping.json,,,,,,,,
+sample1,https://raw.githubusercontent.com/phac-nml/gasclustering/update/input_assure/tests/data/reports/case-hash-missing/sample1.mlst.subtyping.json,,,,,,,,
+sample2,https://raw.githubusercontent.com/phac-nml/gasclustering/update/input_assure/tests/data/reports/case-hash-missing/sample2.mlst.subtyping.json,,,,,,,,
+sample3,https://raw.githubusercontent.com/phac-nml/gasclustering/update/input_assure/tests/data/reports/case-hash-missing/sample3.mlst.subtyping.json,,,,,,,,

--- a/tests/data/samplesheets/samplesheet-hash-more-missing.csv
+++ b/tests/data/samplesheets/samplesheet-hash-more-missing.csv
@@ -1,4 +1,4 @@
 sample,mlst_alleles,metadata_1,metadata_2,metadata_3,metadata_4,metadata_5,metadata_6,metadata_7,metadata_8
-sample1,https://raw.githubusercontent.com/phac-nml/gasclustering/update/profile_dists/tests/data/reports/case-hash-missing/sample1.mlst.subtyping.json,,,,,,,,
-sample2,https://raw.githubusercontent.com/phac-nml/gasclustering/update/profile_dists/tests/data/reports/case-hash-missing/sample2.mlst.subtyping.json,,,,,,,,
-sample3,https://raw.githubusercontent.com/phac-nml/gasclustering/update/profile_dists/tests/data/reports/case-hash-missing/sample3-more-missing.mlst.subtyping.json,,,,,,,,
+sample1,https://raw.githubusercontent.com/phac-nml/gasclustering/update/input_assure/tests/data/reports/case-hash-missing/sample1.mlst.subtyping.json,,,,,,,,
+sample2,https://raw.githubusercontent.com/phac-nml/gasclustering/update/input_assure/tests/data/reports/case-hash-missing/sample2.mlst.subtyping.json,,,,,,,,
+sample3,https://raw.githubusercontent.com/phac-nml/gasclustering/update/input_assure/tests/data/reports/case-hash-missing/sample3-more-missing.mlst.subtyping.json,,,,,,,,

--- a/tests/data/samplesheets/samplesheet-little-metadata.csv
+++ b/tests/data/samplesheets/samplesheet-little-metadata.csv
@@ -1,4 +1,4 @@
 sample,mlst_alleles,metadata_1,metadata_2,metadata_3,metadata_4,metadata_5,metadata_6,metadata_7,metadata_8
-sample1,https://raw.githubusercontent.com/phac-nml/gasclustering/dev/tests/data/reports/sample1.mlst.json,,,,1.4,,,,
-sample2,https://raw.githubusercontent.com/phac-nml/gasclustering/dev/tests/data/reports/sample2.mlst.json,,,,,,,,
-sample3,https://raw.githubusercontent.com/phac-nml/gasclustering/dev/tests/data/reports/sample3.mlst.json,3.1,3.2,,,,,,3.8
+sample1,https://raw.githubusercontent.com/phac-nml/gasclustering/update/input_assure/tests/data/reports/sample1.mlst.json,,,,1.4,,,,
+sample2,https://raw.githubusercontent.com/phac-nml/gasclustering/update/input_assure/tests/data/reports/sample2.mlst.json,,,,,,,,
+sample3,https://raw.githubusercontent.com/phac-nml/gasclustering/update/input_assure/tests/data/reports/sample3.mlst.json,3.1,3.2,,,,,,3.8

--- a/tests/data/samplesheets/samplesheet-mismatched-ids.csv
+++ b/tests/data/samplesheets/samplesheet-mismatched-ids.csv
@@ -1,4 +1,4 @@
 sample,mlst_alleles,metadata_1,metadata_2,metadata_3,metadata_4,metadata_5,metadata_6,metadata_7,metadata_8
-sampleA,https://raw.githubusercontent.com/phac-nml/gasclustering/dev/tests/data/reports/sample1.mlst.json,1.1,1.2,1.3,1.4,1.5,1.6,1.7,1.8
-sampleB,https://raw.githubusercontent.com/phac-nml/gasclustering/dev/tests/data/reports/sample2.mlst.json,2.1,2.2,2.3,2.4,2.5,2.6,2.7,2.8
-sampleC,https://raw.githubusercontent.com/phac-nml/gasclustering/dev/tests/data/reports/sample3.mlst.json,3.1,3.2,3.3,3.4,3.5,3.6,3.7,3.8
+sampleA,https://raw.githubusercontent.com/phac-nml/gasclustering/update/input_assure/tests/data/reports/sample1.mlst.json,1.1,1.2,1.3,1.4,1.5,1.6,1.7,1.8
+sampleB,https://raw.githubusercontent.com/phac-nml/gasclustering/update/input_assure/tests/data/reports/sample2.mlst.json,2.1,2.2,2.3,2.4,2.5,2.6,2.7,2.8
+sampleC,https://raw.githubusercontent.com/phac-nml/gasclustering/update/input_assure/tests/data/reports/sample3.mlst.json,3.1,3.2,3.3,3.4,3.5,3.6,3.7,3.8

--- a/tests/data/samplesheets/samplesheet-no-metadata.csv
+++ b/tests/data/samplesheets/samplesheet-no-metadata.csv
@@ -1,4 +1,4 @@
 sample,mlst_alleles,metadata_1,metadata_2,metadata_3,metadata_4,metadata_5,metadata_6,metadata_7,metadata_8
-sample1,https://raw.githubusercontent.com/phac-nml/gasclustering/dev/tests/data/reports/sample1.mlst.json,,,,,,,,
-sample2,https://raw.githubusercontent.com/phac-nml/gasclustering/dev/tests/data/reports/sample2.mlst.json,,,,,,,,
-sample3,https://raw.githubusercontent.com/phac-nml/gasclustering/dev/tests/data/reports/sample3.mlst.json,,,,,,,,
+sample1,https://raw.githubusercontent.com/phac-nml/gasclustering/update/input_assure/tests/data/reports/sample1.mlst.json,,,,,,,,
+sample2,https://raw.githubusercontent.com/phac-nml/gasclustering/update/input_assure/tests/data/reports/sample2.mlst.json,,,,,,,,
+sample3,https://raw.githubusercontent.com/phac-nml/gasclustering/update/input_assure/tests/data/reports/sample3.mlst.json,,,,,,,,

--- a/tests/data/samplesheets/samplesheet-partial-mismatched-ids.csv
+++ b/tests/data/samplesheets/samplesheet-partial-mismatched-ids.csv
@@ -1,4 +1,4 @@
 sample,mlst_alleles,metadata_1,metadata_2,metadata_3,metadata_4,metadata_5,metadata_6,metadata_7,metadata_8
-sampleA,https://raw.githubusercontent.com/phac-nml/gasclustering/dev/tests/data/reports/sample1.mlst.json,1.1,1.2,1.3,1.4,1.5,1.6,1.7,1.8
-sampleB,https://raw.githubusercontent.com/phac-nml/gasclustering/dev/tests/data/reports/sample2.mlst.json,2.1,2.2,2.3,2.4,2.5,2.6,2.7,2.8
-sample3,https://raw.githubusercontent.com/phac-nml/gasclustering/dev/tests/data/reports/sample3.mlst.json,3.1,3.2,3.3,3.4,3.5,3.6,3.7,3.8
+sampleA,https://raw.githubusercontent.com/phac-nml/gasclustering/update/input_assure/tests/data/reports/sample1.mlst.json,1.1,1.2,1.3,1.4,1.5,1.6,1.7,1.8
+sampleB,https://raw.githubusercontent.com/phac-nml/gasclustering/update/input_assure/tests/data/reports/sample2.mlst.json,2.1,2.2,2.3,2.4,2.5,2.6,2.7,2.8
+sample3,https://raw.githubusercontent.com/phac-nml/gasclustering/update/input_assure/tests/data/reports/sample3.mlst.json,3.1,3.2,3.3,3.4,3.5,3.6,3.7,3.8

--- a/tests/data/samplesheets/samplesheet-tabs.csv
+++ b/tests/data/samplesheets/samplesheet-tabs.csv
@@ -1,4 +1,4 @@
 sample,mlst_alleles,metadata_1,metadata_2,metadata_3,metadata_4,metadata_5,metadata_6,metadata_7,metadata_8
-sample1,https://raw.githubusercontent.com/phac-nml/gasclustering/dev/tests/data/reports/sample1.mlst.json,a	b,,,,,,,
-sample2,https://raw.githubusercontent.com/phac-nml/gasclustering/dev/tests/data/reports/sample2.mlst.json,,,,a	b,,,,
-sample3,https://raw.githubusercontent.com/phac-nml/gasclustering/dev/tests/data/reports/sample3.mlst.json,,,,,,,,a	b
+sample1,https://raw.githubusercontent.com/phac-nml/gasclustering/update/input_assure/tests/data/reports/sample1.mlst.json,a	b,,,,,,,
+sample2,https://raw.githubusercontent.com/phac-nml/gasclustering/update/input_assure/tests/data/reports/sample2.mlst.json,,,,a	b,,,,
+sample3,https://raw.githubusercontent.com/phac-nml/gasclustering/update/input_assure/tests/data/reports/sample3.mlst.json,,,,,,,,a	b

--- a/tests/data/samplesheets/samplesheet1.csv
+++ b/tests/data/samplesheets/samplesheet1.csv
@@ -1,4 +1,4 @@
 sample,mlst_alleles,metadata_1,metadata_2,metadata_3,metadata_4,metadata_5,metadata_6,metadata_7,metadata_8
-sample1,https://raw.githubusercontent.com/phac-nml/gasclustering/dev/tests/data/reports/sample1.mlst.json,1.1,1.2,1.3,1.4,1.5,1.6,1.7,1.8
-sample2,https://raw.githubusercontent.com/phac-nml/gasclustering/dev/tests/data/reports/sample2.mlst.json,2.1,2.2,2.3,2.4,2.5,2.6,2.7,2.8
-sample3,https://raw.githubusercontent.com/phac-nml/gasclustering/dev/tests/data/reports/sample3.mlst.json,3.1,3.2,3.3,3.4,3.5,3.6,3.7,3.8
+sample1,https://raw.githubusercontent.com/phac-nml/gasclustering/update/input_assure/tests/data/reports/sample1.mlst.json,1.1,1.2,1.3,1.4,1.5,1.6,1.7,1.8
+sample2,https://raw.githubusercontent.com/phac-nml/gasclustering/update/input_assure/tests/data/reports/sample2.mlst.json,2.1,2.2,2.3,2.4,2.5,2.6,2.7,2.8
+sample3,https://raw.githubusercontent.com/phac-nml/gasclustering/update/input_assure/tests/data/reports/sample3.mlst.json,3.1,3.2,3.3,3.4,3.5,3.6,3.7,3.8


### PR DESCRIPTION
This PR upgrades the version of the `locidex/merge` module to `locidex:0.2.2` in the container directive. The new version of locidex includes changes to the formatting of generated `mlst.json` allele report files (such as those outputted from [Mikrokondo](https://github.com/phac-nml/mikrokondo)).

To ensure compatibility, the `input_assure` module and python script have been updated to accommodate these changes in the `mlst.json` allele reports. The test data has also been updated to reflect the new `mlst.json` format. All pipeline tests are passing.

New `mlst.json` formatting:
![image](https://github.com/user-attachments/assets/3e184b45-68bf-4624-915a-17d0b700ca12)

Additionally, container directives and closures have been aligned with the `phac-nml/pipeline-standards` as outlined in the [Module Software Requirements and Container Registres](https://github.com/phac-nml/pipeline-standards?tab=readme-ov-file#521-module-software-requirements)

## PR checklist

- [x] This comment contains a description of changes (with reason).
- [x] Make sure your code lints (`nf-core lint`).
- [x] Ensure the test suite passes (`nextflow run . -profile test,docker --outdir <OUTDIR>`).
- [x] Check for unexpected warnings in debug mode (`nextflow run . -profile debug,test,docker --outdir <OUTDIR>`).
- [x] `CHANGELOG.md` is updated.

