### PR TITLE
add `sample_name` as possible column in samplesheet

### DIFF
--- a/.github/workflows/linting.yml
+++ b/.github/workflows/linting.yml
@@ -1,6 +1,6 @@
 name: nf-core linting
 # This workflow is triggered on pushes and PRs to the repository.
-# It runs the `nf-core lint` and markdown lint tests to ensure
+# It runs the `nf-core pipelines lint` and markdown lint tests to ensure
 # that the code meets the nf-core guidelines.
 on:
   push:
@@ -41,17 +41,32 @@ jobs:
           python-version: "3.12"
           architecture: "x64"
 
+      - name: read .nf-core.yml
+        uses: pietrobolcato/action-read-yaml@1.1.0
+        id: read_yml
+        with:
+          config: ${{ github.workspace }}/.nf-core.yml
+
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          pip install nf-core
+          pip install nf-core==${{ steps.read_yml.outputs['nf_core_version'] }}
 
-      - name: Run nf-core lint
+      - name: Run nf-core pipelines lint
+        if: ${{ github.base_ref != 'master' }}
         env:
           GITHUB_COMMENTS_URL: ${{ github.event.pull_request.comments_url }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GITHUB_PR_COMMIT: ${{ github.event.pull_request.head.sha }}
-        run: nf-core -l lint_log.txt lint --dir ${GITHUB_WORKSPACE} --markdown lint_results.md
+        run: nf-core -l lint_log.txt pipelines lint --dir ${GITHUB_WORKSPACE} --markdown lint_results.md
+
+      - name: Run nf-core pipelines lint --release
+        if: ${{ github.base_ref == 'master' }}
+        env:
+          GITHUB_COMMENTS_URL: ${{ github.event.pull_request.comments_url }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_PR_COMMIT: ${{ github.event.pull_request.head.sha }}
+        run: nf-core -l lint_log.txt pipelines lint --release --dir ${GITHUB_WORKSPACE} --markdown lint_results.md
 
       - name: Save PR number
         if: ${{ always() }}

--- a/.github/workflows/linting_comment.yml
+++ b/.github/workflows/linting_comment.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Download lint results
-        uses: dawidd6/action-download-artifact@09f2f74827fd3a8607589e5ad7f9398816f540fe # v3
+        uses: dawidd6/action-download-artifact@bf251b5aa9c2f7eeb574a96ee720e24f801b7c11 # v6
         with:
           workflow: linting.yml
           workflow_conclusion: completed

--- a/.nf-core.yml
+++ b/.nf-core.yml
@@ -1,5 +1,5 @@
 repository_type: pipeline
-nf_core_version: "2.14.1"
+nf_core_version: "3.0.1"
 lint:
   files_exist:
     - assets/nf-core-gasclustering_logo_light.png
@@ -31,6 +31,9 @@ lint:
     - custom_config
     - manifest.name
     - manifest.homePage
+    - params.max_cpus
+    - params.max_memory
+    - params.max_time
   readme:
     - nextflow_badge
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,16 @@
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## In Development
+
+- Added the ability to include a `sample_name` column in the input samplesheet.csv. Allows for compatibility with IRIDA-Next input configuration.
+
+  - `sample_name` special characters will be replaced with `"_"`
+  - If no `sample_name` is supplied in the column `sample` will be used
+  - To avoid repeat values for `sample_name` all `sample_name` values will be suffixed with the unique `sample` value from the input file
+
+  - Fixed linting issues in CI caused by nf-core 3.0.1
+
 ## [0.3.0] - 2024-09-10
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Added the ability to include a `sample_name` column in the input samplesheet.csv. Allows for compatibility with IRIDA-Next input configuration.
 
-  - `sample_name` special characters will be replaced with `"_"`
+  - `sample_name` special characters (non-alphanumeric with exception of "_" and ".") will be replaced with `"_"`
   - If no `sample_name` is supplied in the column `sample` will be used
   - To avoid repeat values for `sample_name` all `sample_name` values will be suffixed with the unique `sample` value from the input file
 

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ The structure of this file is defined in [assets/schema_input.json](assets/schem
 
 `sample_name`: An **optional** column, that overrides `sample` for outputs (filenames and sample names) and reference assembly identification.
 
-`sample_name`, allows more flexibility in naming output files or sample identification. Unlike `sample`, `sample_name` is not required to contain unique values. `Nextflow` requires unique sample names, and therefore in the instance of repeat `sample_names`, `sample` will be suffixed to any `sample_name`. Non-alphanumeric characters (excluding `_`,`-`,`.`) will be replaced with `"_"`.
+`sample_name` allows more flexibility in naming output files or sample identification. Unlike `sample`, `sample_name` is not required to contain unique values. `Nextflow` requires unique sample names, and therefore in the instance of repeat `sample_names`, `sample` will be suffixed to any `sample_name`. Non-alphanumeric characters (excluding `_`,`-`,`.`) will be replaced with `"_"`.
 
 An [example samplesheet](../tests/data/samplesheets/samplesheet-samplename.csv) has been provided with the pipeline.
 

--- a/README.md
+++ b/README.md
@@ -16,6 +16,16 @@ The input to the pipeline is a standard sample sheet (passed as `--input samples
 
 The structure of this file is defined in [assets/schema_input.json](assets/schema_input.json). Validation of the sample sheet is performed by [nf-validation](https://nextflow-io.github.io/nf-validation/). Details on the columns can be found in the [Full samplesheet](docs/usage.md#full-samplesheet) documentation.
 
+## IRIDA-Next Optional Input Configuration
+
+`gasclustering` accepts the [IRIDA-Next](https://github.com/phac-nml/irida-next) format for samplesheets which can contain an additional column: `sample_name`
+
+`sample_name`: An **optional** column, that overrides `sample` for outputs (filenames and sample names) and reference assembly identification.
+
+`sample_name`, allows more flexibility in naming output files or sample identification. Unlike `sample`, `sample_name` is not required to contain unique values. `Nextflow` requires unique sample names, and therefore in the instance of repeat `sample_names`, `sample` will be suffixed to any `sample_name`. Non-alphanumeric characters (excluding `_`,`-`,`.`) will be replaced with `"_"`.
+
+An [example samplesheet](../tests/data/samplesheets/samplesheet-samplename.csv) has been provided with the pipeline.
+
 # Parameters
 
 The main parameters are `--input` as defined above and `--output` for specifying the output results directory. You may wish to provide `-profile singularity` to specify the use of singularity containers and `-r [branch]` to specify which GitHub branch you would like to run.

--- a/assets/schema_input.json
+++ b/assets/schema_input.json
@@ -1,5 +1,5 @@
 {
-    "$schema": "http://json-schema.org/draft-07/schema",
+    "$schema": "https://json-schema.org/draft-07/schema",
     "$id": "https://raw.githubusercontent.com/phac-nml/gasclustering/main/assets/schema_input.json",
     "title": "phac-nml/gasclustering pipeline - params.input schema",
     "description": "Schema for the file provided with params.input",

--- a/assets/schema_input.json
+++ b/assets/schema_input.json
@@ -10,9 +10,14 @@
             "sample": {
                 "type": "string",
                 "pattern": "^\\S+$",
-                "meta": ["id"],
+                "meta": ["irida_id"],
                 "unique": true,
-                "errorMessage": "Sample name must be provided and cannot contain spaces"
+                "errorMessage": "Sample name must be provided and cannot contain spaces."
+            },
+            "sample_name": {
+                "type": "string",
+                "meta": ["id"],
+                "errorMessage": "Sample name is optional, if provided will replace sample for filenames and outputs"
             },
             "mlst_alleles": {
                 "type": "string",

--- a/conf/iridanext.config
+++ b/conf/iridanext.config
@@ -5,7 +5,7 @@ iridanext {
         overwrite = true
         validate = true
         files {
-            idkey = "id"
+            idkey = "irida_id"
             global = [
                 "**/ArborView/arborview.clustered_data_arborview.html",
                 "**/clusters/gas.mcluster.clusters.text",

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -12,7 +12,7 @@ You will need to create a samplesheet with information about the samples you wou
 --input '[path to samplesheet file]'
 ```
 
-### Full samplesheet
+### Full Standard Samplesheet
 
 The input samplesheet must contain 10 columns: `sample`, `mlst_alleles`, `metadata_1`, `metadata_2`, ..., `metadata_8`. The `sample` IDs within a samplesheet should be unique. All other columns outside of the listed above will be ignored.
 
@@ -32,6 +32,30 @@ SAMPLE3,sample3.mlst.subtyping.json.gz,Canada,2021,,,,,,
 | `metadata_1` to `metadata_8` | Optional metadata values to integrate into the final visualization.                                                                                                                                                                                                                                                              |
 
 An [example samplesheet](../assets/samplesheet.csv) has been provided with the pipeline.
+
+### IRIDA-Next Optional Samplesheet Configuration
+
+`gasclustering` accepts the [IRIDA-Next](https://github.com/phac-nml/irida-next) format for samplesheets which contain the following columns: `sample`, `sample_name`, `mlst_alleles`, `metadata_1`, `metadata_2`, ..., `metadata_8`. The `sample` IDs within a samplesheet should be unique. All other columns outside of the listed above will be ignored.
+
+A final samplesheet file consisting of both single- and paired-end data may look something like the one below.
+
+````console
+
+```csv title="samplesheet.csv"
+sample,sample_name,mlst_alleles,metadata_1,metadata_2,metadata_3,metadata_4,metadata_5,metadata_6,metadata_7,metadata_8
+SAMPLE1,S1,sample1.mlst.json.gz,Canada,2024,,,,,,
+SAMPLE2,S2,sample2.mlst.json.gz,USA,2024,,,,,,
+SAMPLE3, ,sample3.mlst.subtyping.json.gz,Canada,2021,,,,,,
+````
+
+| Column                       | Description                                                                                                                                                                                                                                                                                                                      |
+| ---------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `sample`                     | Custom sample name. Samples should be unique within a samplesheet.                                                                                                                                                                                                                                                               |
+| `sample_name`                | Sample name used in outputs (filenames and sample names)                                                                                                                                                                                                                                                                         |
+| `mlst_alleles`               | Full path to an MLST JSON file describing the loci/alleles for the sample against some MLST scheme. A way to generate this file is via [locidex](https://github.com/phac-nml/locidex). File can optionally be gzipped and must have the extension ".mlst.json", ".mlst.subtyping.json" (or with an additional ".gz" if gzipped). |
+| `metadata_1` to `metadata_8` | Optional metadata values to integrate into the final visualization.                                                                                                                                                                                                                                                              |
+
+An [example samplesheet](../tests/data/samplesheets/samplesheet-addsamplename.csv) has been provided with the pipeline.
 
 ## Running the pipeline
 

--- a/modules/local/appendmetadata/main.nf
+++ b/modules/local/appendmetadata/main.nf
@@ -3,11 +3,11 @@ process APPEND_METADATA {
     label 'process_single'
 
     input:
-    val clusters_path     // cluster data as a TSV path
-                          // this needs to be "val", because "path"
-                          // won't stage the file correctly for exec
-    val metadata_rows     // metadata rows (no headers) to be appened, list of lists
-    val metadata_headers  // headers to name the metadata columns
+    val clusters_path       // cluster data as a TSV path
+                            // this needs to be "val", because "path"
+                            // won't stage the file correctly for exec
+    val metadata_rows       // metadata rows (no headers) to be appened, list of lists
+    val metadata_headers    // headers to name the metadata columns
 
     output:
     path("clusters_and_metadata.tsv"), emit: clusters

--- a/modules/local/appendmetadata/main.nf
+++ b/modules/local/appendmetadata/main.nf
@@ -3,10 +3,10 @@ process APPEND_METADATA {
     label 'process_single'
 
     input:
-    val clusters_path  // cluster data as a TSV path
-                        // this needs to be "val", because "path"
-                        // won't stage the file correctly for exec
-    val metadata_rows  // metadata rows (no headers) to be appened, list of lists
+    val clusters_path     // cluster data as a TSV path
+                          // this needs to be "val", because "path"
+                          // won't stage the file correctly for exec
+    val metadata_rows     // metadata rows (no headers) to be appened, list of lists
     val metadata_headers  // headers to name the metadata columns
 
     output:

--- a/nextflow_schema.json
+++ b/nextflow_schema.json
@@ -1,5 +1,5 @@
 {
-    "$schema": "http://json-schema.org/draft-07/schema",
+    "$schema": "https://json-schema.org/draft-07/schema",
     "$id": "https://raw.githubusercontent.com/phac-nml/gasclustering/main/nextflow_schema.json",
     "title": "phac-nml/gasclustering pipeline parameters",
     "description": "IRIDA Next Example Pipeline",

--- a/tests/data/append/expected_clusters_and_metadata-mismatched-ids.tsv
+++ b/tests/data/append/expected_clusters_and_metadata-mismatched-ids.tsv
@@ -1,4 +1,4 @@
-id	address	level_1	level_2	level_3	metadata_1	metadata_2	metadata_3	metadata_4	metadata_5	metadata_6	metadata_7	metadata_8
-sampleA	1.1.1	1	1	1	1.1	1.2	1.3	1.4	1.5	1.6	1.7	1.8
-sampleB	1.1.1	1	1	1	2.1	2.2	2.3	2.4	2.5	2.6	2.7	2.8
-sampleC	1.2.2	1	2	2	3.1	3.2	3.3	3.4	3.5	3.6	3.7	3.8
+id	address	level_1	level_2	level_3	sample	metadata_1	metadata_2	metadata_3	metadata_4	metadata_5	metadata_6	metadata_7	metadata_8
+sampleA	1.1.1	1	1	1	sampleA	1.1	1.2	1.3	1.4	1.5	1.6	1.7	1.8
+sampleB	1.1.1	1	1	1	sampleB	2.1	2.2	2.3	2.4	2.5	2.6	2.7	2.8
+sampleC	1.2.2	1	2	2	sampleC	3.1	3.2	3.3	3.4	3.5	3.6	3.7	3.8

--- a/tests/data/append/expected_clusters_and_metadata-partial-mismatched-ids.tsv
+++ b/tests/data/append/expected_clusters_and_metadata-partial-mismatched-ids.tsv
@@ -1,4 +1,4 @@
-id	address	level_1	level_2	level_3	metadata_1	metadata_2	metadata_3	metadata_4	metadata_5	metadata_6	metadata_7	metadata_8
-sampleA	1.1.1	1	1	1	1.1	1.2	1.3	1.4	1.5	1.6	1.7	1.8
-sampleB	1.1.1	1	1	1	2.1	2.2	2.3	2.4	2.5	2.6	2.7	2.8
-sample3	1.2.2	1	2	2	3.1	3.2	3.3	3.4	3.5	3.6	3.7	3.8
+id	address	level_1	level_2	level_3	sample	metadata_1	metadata_2	metadata_3	metadata_4	metadata_5	metadata_6	metadata_7	metadata_8
+sampleA	1.1.1	1	1	1	sampleA	1.1	1.2	1.3	1.4	1.5	1.6	1.7	1.8
+sampleB	1.1.1	1	1	1	sampleB	2.1	2.2	2.3	2.4	2.5	2.6	2.7	2.8
+sample3	1.2.2	1	2	2	sample3	3.1	3.2	3.3	3.4	3.5	3.6	3.7	3.8

--- a/tests/data/append/expected_clusters_and_metadata.tsv
+++ b/tests/data/append/expected_clusters_and_metadata.tsv
@@ -1,4 +1,4 @@
-id	address	level_1	level_2	level_3	myheader_1	myheader_2	myheader_3	myheader_4	myheader_5	myheader_6	myheader_7	myheader_8
-sample1	1.1.1	1	1	1	1.1	1.2	1.3	1.4	1.5	1.6	1.7	1.8
-sample2	1.1.1	1	1	1	2.1	2.2	2.3	2.4	2.5	2.6	2.7	2.8
-sample3	1.2.2	1	2	2	3.1	3.2	3.3	3.4	3.5	3.6	3.7	3.8
+id	address	level_1	level_2	level_3	sample	myheader_1	myheader_2	myheader_3	myheader_4	myheader_5	myheader_6	myheader_7	myheader_8
+sample1	1.1.1	1	1	1	sample1	1.1	1.2	1.3	1.4	1.5	1.6	1.7	1.8
+sample2	1.1.1	1	1	1	sample2	2.1	2.2	2.3	2.4	2.5	2.6	2.7	2.8
+sample3	1.2.2	1	2	2	sample3	3.1	3.2	3.3	3.4	3.5	3.6	3.7	3.8

--- a/tests/data/append/expected_clusters_and_metadata_addsamplename.tsv
+++ b/tests/data/append/expected_clusters_and_metadata_addsamplename.tsv
@@ -1,0 +1,4 @@
+id	address	level_1	level_2	level_3	sample	metadata_1	metadata_2	metadata_3	metadata_4	metadata_5	metadata_6	metadata_7	metadata_8
+S_1	1.1.1	1	1	1	sample1	1.1	1.2	1.3	1.4	1.5	1.6	1.7	1.8
+S2_	1.1.1	1	1	1	sample2	2.1	2.2	2.3	2.4	2.5	2.6	2.7	2.8
+S2__sample3	1.2.2	1	2	2	sample3	3.1	3.2	3.3	3.4	3.5	3.6	3.7	3.8

--- a/tests/data/append/expected_clusters_and_metadata_hamming.tsv
+++ b/tests/data/append/expected_clusters_and_metadata_hamming.tsv
@@ -1,4 +1,4 @@
-id	address	level_1	level_2	level_3	metadata_1	metadata_2	metadata_3	metadata_4	metadata_5	metadata_6	metadata_7	metadata_8
-sample1	1.1.1	1	1	1								
-sample2	1.1.2	1	1	2								
-sample3	2.2.3	2	2	3								
+id	address	level_1	level_2	level_3	sample	metadata_1	metadata_2	metadata_3	metadata_4	metadata_5	metadata_6	metadata_7	metadata_8
+sample1	1.1.1	1	1	1	sample1								
+sample2	1.1.2	1	1	2	sample2								
+sample3	2.2.3	2	2	3	sample3								

--- a/tests/data/append/expected_clusters_and_metadata_little_metadata.tsv
+++ b/tests/data/append/expected_clusters_and_metadata_little_metadata.tsv
@@ -1,4 +1,4 @@
-id	address	level_1	level_2	level_3	metadata_1	metadata_2	metadata_3	metadata_4	metadata_5	metadata_6	metadata_7	metadata_8
-sample1	1.1.1	1	1	1				1.4				
-sample2	1.1.1	1	1	1								
-sample3	1.2.2	1	2	2	3.1	3.2						3.8
+id	address	level_1	level_2	level_3	sample	metadata_1	metadata_2	metadata_3	metadata_4	metadata_5	metadata_6	metadata_7	metadata_8
+sample1	1.1.1	1	1	1	sample1				1.4				
+sample2	1.1.1	1	1	1	sample2								
+sample3	1.2.2	1	2	2	sample3	3.1	3.2						3.8

--- a/tests/data/append/expected_clusters_and_metadata_no_metadata.tsv
+++ b/tests/data/append/expected_clusters_and_metadata_no_metadata.tsv
@@ -1,4 +1,4 @@
-id	address	level_1	level_2	level_3	metadata_1	metadata_2	metadata_3	metadata_4	metadata_5	metadata_6	metadata_7	metadata_8
-sample1	1.1.1	1	1	1								
-sample2	1.1.1	1	1	1								
-sample3	1.2.2	1	2	2								
+id	address	level_1	level_2	level_3	sample	metadata_1	metadata_2	metadata_3	metadata_4	metadata_5	metadata_6	metadata_7	metadata_8
+sample1	1.1.1	1	1	1	sample1								
+sample2	1.1.1	1	1	1	sample2								
+sample3	1.2.2	1	2	2	sample3								

--- a/tests/data/samplesheets/samplesheet-addsamplename.csv
+++ b/tests/data/samplesheets/samplesheet-addsamplename.csv
@@ -1,0 +1,4 @@
+sample,sample_name,mlst_alleles,metadata_1,metadata_2,metadata_3,metadata_4,metadata_5,metadata_6,metadata_7,metadata_8
+sample1,S 1,https://raw.githubusercontent.com/phac-nml/gasclustering/dev/tests/data/reports/sample1.mlst.json,1.1,1.2,1.3,1.4,1.5,1.6,1.7,1.8
+sample2,S2#,https://raw.githubusercontent.com/phac-nml/gasclustering/dev/tests/data/reports/sample2.mlst.json,2.1,2.2,2.3,2.4,2.5,2.6,2.7,2.8
+sample3,S2_,https://raw.githubusercontent.com/phac-nml/gasclustering/dev/tests/data/reports/sample3.mlst.json,3.1,3.2,3.3,3.4,3.5,3.6,3.7,3.8

--- a/tests/pipelines/main.nf.test
+++ b/tests/pipelines/main.nf.test
@@ -67,8 +67,7 @@ nextflow_pipeline {
             // Check that the ArborView output is created
             def actual_arborview = path("$launchDir/results/ArborView/arborview.clustered_data_arborview.html")
             assert actual_arborview.exists()
-            assert actual_arborview.text.contains("id\\taddress\\tlevel_1\\tlevel_2\\tlevel_3\\tmyheader_1\\tmyheader_2\\tmyheader_3\\tmyheader_4\\tmyheader_5\\tmyheader_6\\tmyheader_7\\tmyheader_8\\nsample1\\t1.1.1\\t1\\t1\\t1\\t1.1\\t1.2\\t1.3\\t1.4\\t1.5\\t1.6\\t1.7\\t1.8\\nsample2\\t1.1.1\\t1\\t1\\t1\\t2.1\\t2.2\\t2.3\\t2.4\\t2.5\\t2.6\\t2.7\\t2.8\\nsample3\\t1.2.2\\t1\\t2\\t2\\t3.1\\t3.2\\t3.3\\t3.4\\t3.5\\t3.6\\t3.7\\t3.8\\n")
-
+            assert actual_arborview.text.contains("id\\taddress\\tlevel_1\\tlevel_2\\tlevel_3\\tsample\\tmyheader_1\\tmyheader_2\\tmyheader_3\\tmyheader_4\\tmyheader_5\\tmyheader_6\\tmyheader_7\\tmyheader_8\\nsample1\\t1.1.1\\t1\\t1\\t1\\tsample1\\t1.1\\t1.2\\t1.3\\t1.4\\t1.5\\t1.6\\t1.7\\t1.8\\nsample2\\t1.1.1\\t1\\t1\\t1\\tsample2\\t2.1\\t2.2\\t2.3\\t2.4\\t2.5\\t2.6\\t2.7\\t2.8\\nsample3\\t1.2.2\\t1\\t2\\t2\\tsample3\\t3.1\\t3.2\\t3.3\\t3.4\\t3.5\\t3.6\\t3.7\\t3.8\\n")
             // compare IRIDA Next JSON output
             def iridanext_json = path("$launchDir/results/iridanext.output.json").json
             def iridanext_global = iridanext_json.files.global
@@ -136,7 +135,7 @@ nextflow_pipeline {
 
             // Check that the ArborView output is created
             def actual_arborview = path("$launchDir/results/ArborView/arborview.clustered_data_arborview.html")
-            assert actual_arborview.text.contains("id\\taddress\\tlevel_1\\tlevel_2\\tlevel_3\\tmetadata_1\\tmetadata_2\\tmetadata_3\\tmetadata_4\\tmetadata_5\\tmetadata_6\\tmetadata_7\\tmetadata_8\\nsample1\\t1.1.1\\t1\\t1\\t1\\t\\t\\t\\t\\t\\t\\t\\t\\nsample2\\t1.1.2\\t1\\t1\\t2\\t\\t\\t\\t\\t\\t\\t\\t\\nsample3\\t2.2.3\\t2\\t2\\t3\\t\\t\\t\\t\\t\\t\\t\\t\\n")
+            assert actual_arborview.text.contains("id\\taddress\\tlevel_1\\tlevel_2\\tlevel_3\\tsample\\tmetadata_1\\tmetadata_2\\tmetadata_3\\tmetadata_4\\tmetadata_5\\tmetadata_6\\tmetadata_7\\tmetadata_8\\nsample1\\t1.1.1\\t1\\t1\\t1\\tsample1\\t\\t\\t\\t\\t\\t\\t\\t\\nsample2\\t1.1.2\\t1\\t1\\t2\\tsample2\\t\\t\\t\\t\\t\\t\\t\\t\\nsample3\\t2.2.3\\t2\\t2\\t3\\tsample3\\t\\t\\t\\t\\t\\t\\t\\t\\n")
 
             // compare IRIDA Next JSON output
             def iridanext_json = path("$launchDir/results/iridanext.output.json").json
@@ -339,7 +338,7 @@ nextflow_pipeline {
             // Check that the ArborView output is created
             def actual_arborview = path("$launchDir/results/ArborView/arborview.clustered_data_arborview.html")
             assert actual_arborview.exists()
-            assert actual_arborview.text.contains("id\\taddress\\tlevel_1\\tlevel_2\\tlevel_3\\tmetadata_1\\tmetadata_2\\tmetadata_3\\tmetadata_4\\tmetadata_5\\tmetadata_6\\tmetadata_7\\tmetadata_8\\nsample1\\t1.1.1\\t1\\t1\\t1\\t\\t\\t\\t\\t\\t\\t\\t\\nsample2\\t1.1.1\\t1\\t1\\t1\\t\\t\\t\\t\\t\\t\\t\\t\\nsample3\\t1.2.2\\t1\\t2\\t2\\t\\t\\t\\t\\t\\t\\t\\t\\n")
+            assert actual_arborview.text.contains("id\\taddress\\tlevel_1\\tlevel_2\\tlevel_3\\tsample\\tmetadata_1\\tmetadata_2\\tmetadata_3\\tmetadata_4\\tmetadata_5\\tmetadata_6\\tmetadata_7\\tmetadata_8\\nsample1\\t1.1.1\\t1\\t1\\t1\\tsample1\\t\\t\\t\\t\\t\\t\\t\\t\\nsample2\\t1.1.1\\t1\\t1\\t1\\tsample2\\t\\t\\t\\t\\t\\t\\t\\t\\nsample3\\t1.2.2\\t1\\t2\\t2\\tsample3\\t\\t\\t\\t\\t\\t\\t\\t\\n")
 
             // compare IRIDA Next JSON output
             def iridanext_json = path("$launchDir/results/iridanext.output.json").json
@@ -411,7 +410,7 @@ nextflow_pipeline {
             // Check that the ArborView output is created
             def actual_arborview = path("$launchDir/results/ArborView/arborview.clustered_data_arborview.html")
             assert actual_arborview.exists()
-            assert actual_arborview.text.contains("id\\taddress\\tlevel_1\\tlevel_2\\tlevel_3\\tmetadata_1\\tmetadata_2\\tmetadata_3\\tmetadata_4\\tmetadata_5\\tmetadata_6\\tmetadata_7\\tmetadata_8\\nsample1\\t1.1.1\\t1\\t1\\t1\\t\\t\\t\\t1.4\\t\\t\\t\\t\\nsample2\\t1.1.1\\t1\\t1\\t1\\t\\t\\t\\t\\t\\t\\t\\t\\nsample3\\t1.2.2\\t1\\t2\\t2\\t3.1\\t3.2\\t\\t\\t\\t\\t\\t3.8\\n")
+            assert actual_arborview.text.contains("id\\taddress\\tlevel_1\\tlevel_2\\tlevel_3\\tsample\\tmetadata_1\\tmetadata_2\\tmetadata_3\\tmetadata_4\\tmetadata_5\\tmetadata_6\\tmetadata_7\\tmetadata_8\\nsample1\\t1.1.1\\t1\\t1\\t1\\tsample1\\t\\t\\t\\t1.4\\t\\t\\t\\t\\nsample2\\t1.1.1\\t1\\t1\\t1\\tsample2\\t\\t\\t\\t\\t\\t\\t\\t\\nsample3\\t1.2.2\\t1\\t2\\t2\\tsample3\\t3.1\\t3.2\\t\\t\\t\\t\\t\\t3.8\\n")
 
             // compare IRIDA Next JSON output
             def iridanext_json = path("$launchDir/results/iridanext.output.json").json
@@ -497,7 +496,7 @@ nextflow_pipeline {
             // Check that the ArborView output is created
             def actual_arborview = path("$launchDir/results/ArborView/arborview.clustered_data_arborview.html")
             assert actual_arborview.exists()
-            assert actual_arborview.text.contains("id\\taddress\\tlevel_1\\tlevel_2\\tlevel_3\\tmetadata_1\\tmetadata_2\\tmetadata_3\\tmetadata_4\\tmetadata_5\\tmetadata_6\\tmetadata_7\\tmetadata_8\\nsampleA\\t1.1.1\\t1\\t1\\t1\\t1.1\\t1.2\\t1.3\\t1.4\\t1.5\\t1.6\\t1.7\\t1.8\\nsampleB\\t1.1.1\\t1\\t1\\t1\\t2.1\\t2.2\\t2.3\\t2.4\\t2.5\\t2.6\\t2.7\\t2.8\\nsampleC\\t1.2.2\\t1\\t2\\t2\\t3.1\\t3.2\\t3.3\\t3.4\\t3.5\\t3.6\\t3.7\\t3.8\\n")
+            assert actual_arborview.text.contains("id\\taddress\\tlevel_1\\tlevel_2\\tlevel_3\\tsample\\tmetadata_1\\tmetadata_2\\tmetadata_3\\tmetadata_4\\tmetadata_5\\tmetadata_6\\tmetadata_7\\tmetadata_8\\nsampleA\\t1.1.1\\t1\\t1\\t1\\tsampleA\\t1.1\\t1.2\\t1.3\\t1.4\\t1.5\\t1.6\\t1.7\\t1.8\\nsampleB\\t1.1.1\\t1\\t1\\t1\\tsampleB\\t2.1\\t2.2\\t2.3\\t2.4\\t2.5\\t2.6\\t2.7\\t2.8\\nsampleC\\t1.2.2\\t1\\t2\\t2\\tsampleC\\t3.1\\t3.2\\t3.3\\t3.4\\t3.5\\t3.6\\t3.7\\t3.8\\n")
 
             // compare IRIDA Next JSON output
             def iridanext_json = path("$launchDir/results/iridanext.output.json").json
@@ -580,9 +579,76 @@ nextflow_pipeline {
             // Check that the ArborView output is created
             def actual_arborview = path("$launchDir/results/ArborView/arborview.clustered_data_arborview.html")
             assert actual_arborview.exists()
-            assert actual_arborview.text.contains("id\\taddress\\tlevel_1\\tlevel_2\\tlevel_3\\tmetadata_1\\tmetadata_2\\tmetadata_3\\tmetadata_4\\tmetadata_5\\tmetadata_6\\tmetadata_7\\tmetadata_8\\nsampleA\\t1.1.1\\t1\\t1\\t1\\t1.1\\t1.2\\t1.3\\t1.4\\t1.5\\t1.6\\t1.7\\t1.8\\nsampleB\\t1.1.1\\t1\\t1\\t1\\t2.1\\t2.2\\t2.3\\t2.4\\t2.5\\t2.6\\t2.7\\t2.8\\nsample3\\t1.2.2\\t1\\t2\\t2\\t3.1\\t3.2\\t3.3\\t3.4\\t3.5\\t3.6\\t3.7\\t3.8\\n")
+            assert actual_arborview.text.contains("id\\taddress\\tlevel_1\\tlevel_2\\tlevel_3\\tsample\\tmetadata_1\\tmetadata_2\\tmetadata_3\\tmetadata_4\\tmetadata_5\\tmetadata_6\\tmetadata_7\\tmetadata_8\\nsampleA\\t1.1.1\\t1\\t1\\t1\\tsampleA\\t1.1\\t1.2\\t1.3\\t1.4\\t1.5\\t1.6\\t1.7\\t1.8\\nsampleB\\t1.1.1\\t1\\t1\\t1\\tsampleB\\t2.1\\t2.2\\t2.3\\t2.4\\t2.5\\t2.6\\t2.7\\t2.8\\nsample3\\t1.2.2\\t1\\t2\\t2\\tsample3\\t3.1\\t3.2\\t3.3\\t3.4\\t3.5\\t3.6\\t3.7\\t3.8\\n")
 
             // compare IRIDA Next JSON output
+            def iridanext_json = path("$launchDir/results/iridanext.output.json").json
+            def iridanext_global = iridanext_json.files.global
+            def iridanext_samples = iridanext_json.files.samples
+            def iridanext_metadata = iridanext_json.metadata.samples
+
+            assert iridanext_global.findAll { it.path == "ArborView/arborview.clustered_data_arborview.html" }.size() == 1
+            assert iridanext_global.findAll { it.path == "clusters/gas.mcluster.run.json" }.size() == 1
+            assert iridanext_global.findAll { it.path == "clusters/gas.mcluster.tree.nwk" }.size() == 1
+            assert iridanext_global.findAll { it.path == "clusters/gas.mcluster.clusters.text" }.size() == 1
+            assert iridanext_global.findAll { it.path == "clusters/gas.mcluster.thresholds.json" }.size() == 1
+            assert iridanext_global.findAll { it.path == "distances/profile_dists.run.json" }.size() == 1
+            assert iridanext_global.findAll { it.path == "distances/profile_dists.results.text" }.size() == 1
+            assert iridanext_global.findAll { it.path == "distances/profile_dists.ref_profile.text" }.size() == 1
+            assert iridanext_global.findAll { it.path == "distances/profile_dists.query_profile.text" }.size() == 1
+            assert iridanext_global.findAll { it.path == "distances/profile_dists.allele_map.json" }.size() == 1
+            assert iridanext_global.findAll { it.path == "merged/locidex.merge.profile.tsv" }.size() == 1
+
+            assert iridanext_samples.isEmpty()
+            assert iridanext_metadata.isEmpty()
+        }
+    }
+
+    test("Testing sample_name column in samplesheet") {
+        tag "add_sample_name"
+
+        when {
+            params {
+                input = "$baseDir/tests/data/samplesheets/samplesheet-addsamplename.csv"
+                outdir = "results"
+
+                pd_distm = "scaled"
+                gm_thresholds = "50,20,0"
+
+                metadata_1_header = "metadata_1"
+                metadata_2_header = "metadata_2"
+                metadata_3_header = "metadata_3"
+                metadata_4_header = "metadata_4"
+                metadata_5_header = "metadata_5"
+                metadata_6_header = "metadata_6"
+                metadata_7_header = "metadata_7"
+                metadata_8_header = "metadata_8"
+            }
+        }
+
+        then {
+            assert workflow.success
+            assert path("$launchDir/results").exists()
+
+            // Check ID correction occured:
+            def sample1_report = path("$launchDir/results/input/S_1_error_report.csv")
+            def sample2_report = path("$launchDir/results/input/S2__error_report.csv")
+            def sample3_report = path("$launchDir/results/input/S2__sample3_error_report.csv")
+            assert sample1_report.exists() == true
+            assert sample2_report.exists() == true
+            assert sample3_report.exists() == true
+
+            // Check appended metadata is correct:
+            def actual_metadata = path("$launchDir/results/append/clusters_and_metadata.tsv")
+            assert actual_metadata.exists()
+            def expected_metadata = path("$baseDir/tests/data/append/expected_clusters_and_metadata_addsamplename.tsv")
+            assert actual_metadata.text == expected_metadata.text
+
+            // Check that the ArborView output is created
+            def actual_arborview = path("$launchDir/results/ArborView/arborview.clustered_data_arborview.html")
+            assert actual_arborview.exists()
+            assert actual_arborview.text.contains("id\\taddress\\tlevel_1\\tlevel_2\\tlevel_3\\tsample\\tmetadata_1\\tmetadata_2\\tmetadata_3\\tmetadata_4\\tmetadata_5\\tmetadata_6\\tmetadata_7\\tmetadata_8\\nS_1\\t1.1.1\\t1\\t1\\t1\\tsample1\\t1.1\\t1.2\\t1.3\\t1.4\\t1.5\\t1.6\\t1.7\\t1.8\\nS2_\\t1.1.1\\t1\\t1\\t1\\tsample2\\t2.1\\t2.2\\t2.3\\t2.4\\t2.5\\t2.6\\t2.7\\t2.8\\nS2__sample3\\t1.2.2\\t1\\t2\\t2\\tsample3\\t3.1\\t3.2\\t3.3\\t3.4\\t3.5\\t3.6\\t3.7\\t3.8\\n")
+            // compare IRIDA Next JSON output (should not be changed by adding sample_name column)
             def iridanext_json = path("$launchDir/results/iridanext.output.json").json
             def iridanext_global = iridanext_json.files.global
             def iridanext_samples = iridanext_json.files.samples

--- a/workflows/gasclustering.nf
+++ b/workflows/gasclustering.nf
@@ -67,8 +67,7 @@ def prepareFilePath(String filep){
 }
 
 workflow GASCLUSTERING {
-    ID_COLUMN = "sample_name"
-    ID_COLUMN2 = "sample"
+    SAMPLE_HEADER = "sample"
     ch_versions = Channel.empty()
 
     // Track processed IDs
@@ -104,7 +103,7 @@ workflow GASCLUSTERING {
 
     metadata_headers = Channel.of(
         tuple(
-            ID_COLUMN2,
+            SAMPLE_HEADER,
             params.metadata_1_header, params.metadata_2_header,
             params.metadata_3_header, params.metadata_4_header,
             params.metadata_5_header, params.metadata_6_header,


### PR DESCRIPTION
Modified the template for input `samplesheet.csv` file to include the `sample_name` column in addition to `sample` in-line with changes to [IRIDA-Next update] as seen with the [speciesabundance pipeline] and [staramrnf] for example. What this means is that the output files and the `sample` name will be changed to `sample_name` if a `sample_name` is called. If `gasclustering` is being locally then the `sample_name` can be left blank.

Made a few changes:
    - `sample_name` special characters will be replaced with `"_"`
    - If no `sample_name` is supplied in the column `sample` will be used
    - To avoid repeat values for `sample_name` all `sample_name` values will be suffixed with `sample`
    - Tests to check that the variety of different `sample_names` work with the 

## PR checklist

- [x] This comment contains a description of changes (with reason).
- [x] If you've fixed a bug or added code that should be tested, add tests!
- [x] Make sure your code lints (`nf-core lint`).
- [x] Ensure the test suite passes (`nextflow run . -profile test,docker --outdir <OUTDIR>`).
- [x] Add `nf-test` to test new feature
- [x] Usage Documentation in `docs/usage.md` is updated.
- [x] `CHANGELOG.md` is updated.
- [x] `README.md` is updated (including new tool citations and authors/contributors).
- [x] Tested out in IRIDA-Next locally
- [x] Tested in Azure

[IRIDA-Next update]: https://github.com/phac-nml/irida-next/pull/678
[speciesabundance pipeline]: https://github.com/phac-nml/speciesabundance/pull/24
[staramrnf]: https://github.com/phac-nml/staramrnf/pull/28
