### PR TITLE
Updated GAS version to 0.1.4

### DIFF
--- a/modules/local/gas/mcluster/main.nf
+++ b/modules/local/gas/mcluster/main.nf
@@ -5,8 +5,8 @@ process GAS_MCLUSTER{
     tag "Denovo Clustering"
 
     container "${ workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ?
-        'https://depot.galaxyproject.org/singularity/genomic_address_service%3A0.1.3--pyh7e72e81_0' :
-        'biocontainers/genomic_address_service:0.1.3--pyh7e72e81_0' }"
+        'https://depot.galaxyproject.org/singularity/genomic_address_service%3A0.1.4--pyh7e72e81_0' :
+        'biocontainers/genomic_address_service:0.1.4--pyh7e72e81_0' }"
 
     input:
     path(dist_matrix)


### PR DESCRIPTION
Updated the container used in `GAS_MCLUSTER` with GAS patch release [0.1.4](https://github.com/phac-nml/genomic_address_service/releases/tag/0.1.4).

Changes in patch release were related to `gas call` not `gas mcluster` which is used by `gasclustering` so had no impact on the tests. 

<!--
# phac-nml/gasclustering pull request

Many thanks for contributing to phac-nml/gasclustering!

Please fill in the appropriate checklist below (delete whatever is not relevant).
These are the most common things requested on pull requests (PRs).

Remember that PRs should be made against the dev branch, unless you're preparing a pipeline release.

Learn more about contributing: [CONTRIBUTING.md](https://github.com/phac-nml/gasclustering/tree/main/.github/CONTRIBUTING.md)
-->

## PR checklist

- [x] This comment contains a description of changes (with reason).
- [x] If you've fixed a bug or added code that should be tested, add tests!
- [x] Make sure your code lints (`nf-core lint`).
- [x] Ensure the test suite passes (`nextflow run . -profile test,docker --outdir <OUTDIR>`).
- [x] Check for unexpected warnings in debug mode (`nextflow run . -profile debug,test,docker --outdir <OUTDIR>`).

