### PR TITLE
patch: locidex merge input channel

### DIFF
--- a/modules/local/locidex/merge/main.nf
+++ b/modules/local/locidex/merge/main.nf
@@ -10,7 +10,7 @@ process LOCIDEX_MERGE {
 
     input:
     tuple val(batch_index), path(input_values) // [file(sample1), file(sample2), file(sample3), etc...]
-    val  merge_tsv
+    path  merge_tsv
 
     output:
     path("${combined_dir}/profile_${batch_index}.tsv"),           emit: combined_profiles


### PR DESCRIPTION
The input channel for `LOCIDEX_MERGE` should be a `path` not `val`.

`val` causing issues with file-access on certain cloud-infrastructure, and was missed until tested in `DEV`

https://github.com/phac-nml/gasclustering/blob/588a617e25e7d1a4f6cb5706fef2d0909eaef560/modules/local/locidex/merge/main.nf#L3-L13
