### PR TITLE
Update locidex 0.4.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,14 @@
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.7.3] - 2025-09-03
+
+### `Updated`
+
+- Upgraded `locidex` to [v.0.4.0](https://github.com/phac-nml/locidex/releases/tag/v0.4.0). [PR #59](https://github.com/phac-nml/gasclustering/pull/59)
+
+### `Updated`
+
 ## [0.7.2] - 2025-08-08
 
 ### `Updated`
@@ -150,3 +158,4 @@ Initial release of the Genomic Address Service Clustering pipeline to be used fo
 [0.7.0]: https://github.com/phac-nml/gasclustering/releases/tag/0.7.0
 [0.7.1]: https://github.com/phac-nml/gasclustering/releases/tag/0.7.1
 [0.7.2]: https://github.com/phac-nml/gasclustering/releases/tag/0.7.2
+[0.7.3]: https://github.com/phac-nml/gasclustering/releases/tag/0.7.3

--- a/modules/local/locidex/merge/main.nf
+++ b/modules/local/locidex/merge/main.nf
@@ -5,8 +5,8 @@ process LOCIDEX_MERGE {
     label 'process_medium'
 
     container "${ workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ?
-        'https://depot.galaxyproject.org/singularity/locidex%3A0.3.0--pyhdfd78af_0' :
-        'biocontainers/locidex:0.3.0--pyhdfd78af_0' }"
+        'https://depot.galaxyproject.org/singularity/locidex%3A0.4.0--pyhdfd78af_0' :
+        'biocontainers/locidex:0.4.0--pyhdfd78af_0' }"
 
     input:
     tuple val(batch_index), path(input_values) // [file(sample1), file(sample2), file(sample3), etc...]


### PR DESCRIPTION
Update `locidex` to version 0.4.0 
    - All tests should continue to pass
    - No changes to workflow or process
