### PR TITLE
Update gas 0.3.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,16 @@
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.8.1] - 2025-mm-dd
+
+## `Changed`
+
+- Version of `genomic address service` in `gas` module to `0.3.1`. [PR #69](https://github.com/phac-nml/gasclustering/pull/69)
+
+## `Added`
+
+- Added the `gm_sort_matrix` parameter to `genomic address service` module which sorts the input matrix for `gas mcluster` to allow for deterministic cluster prediction. [PR #69](https://github.com/phac-nml/gasclustering/pull/69)
+
 ## [0.8.0] - 2025-11-17
 
 ### `Changed`
@@ -176,3 +186,4 @@ Initial release of the Genomic Address Service Clustering pipeline to be used fo
 [0.7.2]: https://github.com/phac-nml/gasclustering/releases/tag/0.7.2
 [0.7.3]: https://github.com/phac-nml/gasclustering/releases/tag/0.7.3
 [0.8.0]: https://github.com/phac-nml/gasclustering/releases/tag/0.8.0
+[0.8.1]: https://github.com/phac-nml/gasclustering/releases/tag/0.8.1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,11 +3,15 @@
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [0.8.1] - 2025-mm-dd
+## [0.8.1] - 2026-mm-dd
 
 ## `Changed`
 
-- Version of `genomic address service` in `gas` module to `0.3.1`. [PR #69](https://github.com/phac-nml/gasclustering/pull/69)
+- Version of `genomic address service` in `gas` module to `0.3.2`. [PR #69](https://github.com/phac-nml/gasclustering/pull/69)
+
+## `Added`
+
+- Add a parameter `gm_sort_matrix` which implements the `sort_matrix` option for `gas_mcluster` which sorts the rows and columns of the input matrix to increase the deterministic outputs of clusters.
 
 ## `Added`
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,15 +3,11 @@
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [0.8.1] - 2026-mm-dd
+## [0.8.1] - 2026-01-06
 
 ## `Changed`
 
 - Version of `genomic address service` in `gas` module to `0.3.2`. [PR #69](https://github.com/phac-nml/gasclustering/pull/69)
-
-## `Added`
-
-- Add a parameter `gm_sort_matrix` which implements the `sort_matrix` option for `gas_mcluster` which sorts the rows and columns of the input matrix to increase the deterministic outputs of clusters.
 
 ## `Added`
 

--- a/README.md
+++ b/README.md
@@ -83,6 +83,7 @@ The following can be used to adjust parameters for the [gas mcluster][] tool.
 - `--gm_method`: The linkage method to use for clustering. Value should be one of _single_, _average_, or _complete_.
 - `--gm_delimiter`: Delimiter desired for nomenclature code. Must be alphanumeric or one of `._-`.
 - `--gm_tree_distances`: Defines how distances in the input matrix are represented (`cophenetic` or `patristic`) in the output tree (Newick file). Default: `cophenetic`
+- `--gm_sort_matrix`: Sorts the input matrix (rows/columns) to avoid non-deterministic clusters based on sample order.
 
 ## Other
 

--- a/conf/modules.config
+++ b/conf/modules.config
@@ -56,6 +56,7 @@ process {
             saveAs: { filename -> filename.equals('versions.yml') ? null :
                 filename.contains(File.separator) ? task.cluster_prefix + filename.split(File.separator)[-1] : task.cluster_prefix + filename }
         ]
+        ext.args = { params.gm_sort_matrix? "--sort_matrix" : null }
     }
 
     withName: PROFILE_DISTS {

--- a/modules/local/gas/mcluster/main.nf
+++ b/modules/local/gas/mcluster/main.nf
@@ -5,8 +5,8 @@ process GAS_MCLUSTER{
     tag "Denovo Clustering"
 
     container "${ workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ?
-        'biocontainers/genomic_address_service:0.3.1--pyhdfd78af_0' :
-        'biocontainers/genomic_address_service:0.3.1--pyhdfd78af_0' }"
+        'biocontainers/genomic_address_service:0.3.2--pyhdfd78af_0' :
+        'biocontainers/genomic_address_service:0.3.2--pyhdfd78af_0' }"
 
     input:
     path(dist_matrix)

--- a/modules/local/gas/mcluster/main.nf
+++ b/modules/local/gas/mcluster/main.nf
@@ -5,8 +5,8 @@ process GAS_MCLUSTER{
     tag "Denovo Clustering"
 
     container "${ workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ?
-        'biocontainers/genomic_address_service:0.3.0--pyhdfd78af_0' :
-        'biocontainers/genomic_address_service:0.3.0--pyhdfd78af_0' }"
+        'biocontainers/genomic_address_service:0.3.1--pyhdfd78af_0' :
+        'biocontainers/genomic_address_service:0.3.1--pyhdfd78af_0' }"
 
     input:
     path(dist_matrix)

--- a/modules/local/gas/mcluster/main.nf
+++ b/modules/local/gas/mcluster/main.nf
@@ -21,13 +21,15 @@ process GAS_MCLUSTER{
 
     script:
     prefix = "clusters"
+    def args = task.ext.args ?: ''
     """
     gas mcluster --matrix $dist_matrix \\
                 --outdir $prefix \\
                 --method '${params.gm_method}' \\
                 --threshold ${params.gm_thresholds} \\
                 --delimiter '${params.gm_delimiter}' \\
-                --tree-distances '${params.gm_tree_distances}'
+                --tree-distances '${params.gm_tree_distances}' \\
+                ${args}
 
     # Change the file extension of gas mcluster outputs for the clusters.text file
 

--- a/nextflow.config
+++ b/nextflow.config
@@ -59,6 +59,7 @@ params {
     gm_method = "average"
     gm_delimiter = "."
     gm_tree_distances = "cophenetic"
+    gm_sort_matrix = false
 
     // Metadata
     metadata_1_header = "metadata_1"

--- a/nextflow.config
+++ b/nextflow.config
@@ -242,7 +242,7 @@ manifest {
     description     = """IRIDA Next Genomic Address Service Clustering Pipeline"""
     mainScript      = 'main.nf'
     nextflowVersion = '!>=23.04.0'
-    version         = '0.8.0'
+    version         = '0.8.1'
     doi             = ''
     defaultBranch   = 'main'
 }

--- a/nextflow_schema.json
+++ b/nextflow_schema.json
@@ -253,6 +253,11 @@
                     "default": "cophenetic",
                     "description": "Defines how distances in the input matrix are represented in the output tree (Newick file).",
                     "enum": ["cophenetic", "patristic"]
+                },
+                "gm_sort_matrix": {
+                    "type": "boolean",
+                    "default": false,
+                    "description": "Sorts the rows and columns of the distance matrix input to create deterministic clusters"
                 }
             }
         },

--- a/tests/data/clusters/expected_clusters_sorted.tsv
+++ b/tests/data/clusters/expected_clusters_sorted.tsv
@@ -1,0 +1,11 @@
+id	address	level_1	level_2	level_3	level_4	level_5	level_6
+1_ingroup_10	1.1.1.1.2.3	1	1	1	1	2	3
+1_ingroup_11	1.1.1.1.3.4	1	1	1	1	3	4
+1_ingroup_12	1.1.1.1.1.1	1	1	1	1	1	1
+1_ingroup_13	1.1.1.1.4.5	1	1	1	1	4	5
+1_ingroup_14	1.1.1.1.1.2	1	1	1	1	1	2
+1_outgroup_15	4.4.4.4.7.8	4	4	4	4	7	8
+1_outgroup_16	2.2.2.2.5.6	2	2	2	2	5	6
+1_outgroup_17	5.5.5.5.8.9	5	5	5	5	8	9
+1_outgroup_18	3.3.3.3.6.7	3	3	3	3	6	7
+1_outgroup_19	6.6.6.6.9.10	6	6	6	6	9	10

--- a/tests/data/samplesheets/samplesheet-sample-order-fix.csv
+++ b/tests/data/samplesheets/samplesheet-sample-order-fix.csv
@@ -1,0 +1,11 @@
+sample,mlst_alleles
+1_ingroup_14,https://raw.githubusercontent.com/phac-nml/gasclustering/dev/tests/data/profiles/sample-order-fix/1_ingroup_14.locidex.report.profile.mlst.subtyping.json.gz
+1_outgroup_17,https://raw.githubusercontent.com/phac-nml/gasclustering/dev/tests/data/profiles/sample-order-fix/1_outgroup_17.locidex.report.profile.mlst.subtyping.json.gz
+1_ingroup_12,https://raw.githubusercontent.com/phac-nml/gasclustering/dev/tests/data/profiles/sample-order-fix/1_ingroup_12.locidex.report.profile.mlst.subtyping.json.gz
+1_ingroup_13,https://raw.githubusercontent.com/phac-nml/gasclustering/dev/tests/data/profiles/sample-order-fix/1_ingroup_13.locidex.report.profile.mlst.subtyping.json.gz
+1_ingroup_11,https://raw.githubusercontent.com/phac-nml/gasclustering/dev/tests/data/profiles/sample-order-fix/1_ingroup_11.locidex.report.profile.mlst.subtyping.json.gz
+1_outgroup_16,https://raw.githubusercontent.com/phac-nml/gasclustering/dev/tests/data/profiles/sample-order-fix/1_outgroup_16.locidex.report.profile.mlst.subtyping.json.gz
+1_outgroup_18,https://raw.githubusercontent.com/phac-nml/gasclustering/dev/tests/data/profiles/sample-order-fix/1_outgroup_18.locidex.report.profile.mlst.subtyping.json.gz
+1_outgroup_15,https://raw.githubusercontent.com/phac-nml/gasclustering/dev/tests/data/profiles/sample-order-fix/1_outgroup_15.locidex.report.profile.mlst.subtyping.json.gz
+1_outgroup_19,https://raw.githubusercontent.com/phac-nml/gasclustering/dev/tests/data/profiles/sample-order-fix/1_outgroup_19.locidex.report.profile.mlst.subtyping.json.gz
+1_ingroup_10,https://raw.githubusercontent.com/phac-nml/gasclustering/dev/tests/data/profiles/sample-order-fix/1_ingroup_10.locidex.report.profile.mlst.subtyping.json.gz

--- a/tests/pipelines/main.nf.test
+++ b/tests/pipelines/main.nf.test
@@ -831,4 +831,31 @@ nextflow_pipeline {
             def iridanext_metadata = iridanext_json.metadata.samples
         }
     }
+    test("Testing GAS --sort_matrix parameter") {
+        tag "gas_sort_matrix"
+        // Recreating an issue where order of samples passed to gas mcluster caused non-deterministic clusters (https://github.com/phac-nml/genomic_address_service/issues/55)
+        // When the gas mcluster parameter (--sort_matrix) is used the clusters will always output the same clusters, regardless of samplesheet
+        when {
+            params {
+                input = "$baseDir/tests/data/samplesheets/samplesheet-sample-order-fix.csv"
+                outdir = "results"
+
+                pd_distm = "hamming"
+                gm_thresholds = "30,25,20,15,10,5"
+                gm_sort_matrix true
+
+            }
+        }
+
+        then {
+            assert workflow.success
+            assert path("$launchDir/results").exists()
+
+            // Check computed clusters are correct and exist
+            def actual_clusters = path("$launchDir/results/clusters/gas.mcluster.clusters.tsv")
+            assert actual_clusters.exists()
+            def expected_clusters = path("$baseDir/tests/data/clusters/expected_clusters_sorted.tsv")
+            assert actual_clusters.text ==  expected_clusters.text
+        }
+    }
 }

--- a/tests/pipelines/main.nf.test
+++ b/tests/pipelines/main.nf.test
@@ -842,7 +842,7 @@ nextflow_pipeline {
 
                 pd_distm = "hamming"
                 gm_thresholds = "30,25,20,15,10,5"
-                gm_sort_matrix true
+                gm_sort_matrix = true
 
             }
         }


### PR DESCRIPTION
### Update GAS module

### NOTE: 
The most recent version of GAS is now 0.3.2, which was updated mid-change of the PR, so we have updated this PR

Update the GAS module to version [0.3.2](https://github.com/phac-nml/genomic_address_service/releases/tag/0.3.2)
- Add a parameter `gm_sort_matrix` which implements the `sort_matrix` option for `gas_mcluster` which sorts the rows and columns of the input matrix to increase the deterministic outputs of clusters.
- Add tests to confirm the command is performing correctly   
