### PR TITLE
Fixed up container options to only pass for locidex merge for docker

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Updated GitHub Actions and nf-test configuration to latest versions provided by `nf-core` pipelines template. [PR #73](https://github.com/phac-nml/gasclustering/pull/73)
 - Updated minimum Nextflow version for pipeline to be `24.10.3`. [PR #73](https://github.com/phac-nml/gasclustering/pull/73)
 
+### `Fixed`
+
+- Fixed `containerOptions` string so the required options are only passed when using the `docker` profile (and not for `singularity`). [PR #75](https://github.com/phac-nml/gasclustering/pull/75)
+
 ## [0.8.2] - 2026-01-13
 
 - Increased the number of default metadata columns from 16 to 24. [PR #71](https://github.com/phac-nml/gasclustering/pull/71)

--- a/conf/modules.config
+++ b/conf/modules.config
@@ -31,7 +31,6 @@ process {
     ]
 
     withName: LOCIDEX_MERGE {
-        containerOptions = '-e USER=nextflow -e HOME=/tmp'
         publishDir = [
             path: locidex_merge_directory_name,
             mode: params.publish_dir_mode,

--- a/modules/local/locidex/merge/main.nf
+++ b/modules/local/locidex/merge/main.nf
@@ -8,6 +8,8 @@ process LOCIDEX_MERGE {
         'https://depot.galaxyproject.org/singularity/locidex%3A0.4.0--pyhdfd78af_0' :
         'biocontainers/locidex:0.4.0--pyhdfd78af_0' }"
 
+    containerOptions "${task.ext.containerOptions ?: ''}"
+
     input:
     tuple val(batch_index), path(input_values) // [file(sample1), file(sample2), file(sample3), etc...]
     path  merge_tsv

--- a/nextflow.config
+++ b/nextflow.config
@@ -131,6 +131,7 @@ profiles {
         charliecloud.enabled   = false
         apptainer.enabled      = false
         docker.runOptions      = '-u $(id -u):$(id -g)'
+        process.ext.containerOptions = '-e USER=nextflow -e HOME=/tmp'
     }
     arm {
         docker.runOptions      = '-u $(id -u):$(id -g) --platform=linux/amd64'


### PR DESCRIPTION
Fixes up container options to only pass specific options when running with `-profile docker`. 

This is a similar fix as was previously applied to the `gasnomenclature` pipeline: https://github.com/phac-nml/gasnomenclature/pull/88

*Note: tests using `singularity` containers only run on GitHub when merging to `main` for the release (i.e., PR #74 ). I have ran these tests using `-profile singularity` on my local machine and they all pass.*

## PR checklist

- [x] This comment contains a description of changes (with reason).
- [x] Make sure your code lints (`nf-core lint`).
- [x] Ensure the test suite passes (`nextflow run . -profile test,docker --outdir <OUTDIR>`).
- [x] Check for unexpected warnings in debug mode (`nextflow run . -profile debug,test,docker --outdir <OUTDIR>`).
- [x] `CHANGELOG.md` is updated.
